### PR TITLE
refactor: centralize styles and responsive design

### DIFF
--- a/assets/icons/communication.svg
+++ b/assets/icons/communication.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#0052a5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+  <circle cx="9" cy="7" r="4"/>
+  <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+  <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+</svg>

--- a/assets/icons/info-quality.svg
+++ b/assets/icons/info-quality.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#0052a5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <line x1="12" y1="16" x2="12" y2="12"/>
+  <line x1="12" y1="8" x2="12.01" y2="8"/>
+</svg>

--- a/assets/icons/process.svg
+++ b/assets/icons/process.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#0052a5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="3 11 3 7 21 7 21 11"/>
+  <polyline points="3 13 3 17 21 17 21 13"/>
+</svg>

--- a/assets/icons/satisfaction.svg
+++ b/assets/icons/satisfaction.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#0052a5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <path d="M8 14s1.5 2 4 2 4-2 4-2"/>
+  <line x1="9" y1="9" x2="9.01" y2="9"/>
+  <line x1="15" y1="9" x2="15.01" y2="9"/>
+</svg>

--- a/assets/icons/system-quality.svg
+++ b/assets/icons/system-quality.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#0052a5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="4" width="16" height="16" rx="2" ry="2"/>
+  <rect x="9" y="9" width="6" height="6"/>
+  <line x1="9" y1="1" x2="9" y2="4"/>
+  <line x1="15" y1="1" x2="15" y2="4"/>
+  <line x1="9" y1="20" x2="9" y2="23"/>
+  <line x1="15" y1="20" x2="15" y2="23"/>
+  <line x1="20" y1="9" x2="23" y2="9"/>
+  <line x1="20" y1="15" x2="23" y2="15"/>
+  <line x1="1" y1="9" x2="4" y2="9"/>
+  <line x1="1" y1="15" x2="4" y2="15"/>
+</svg>

--- a/assets/icons/workload.svg
+++ b/assets/icons/workload.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#0052a5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <polyline points="12 6 12 12 16 14"/>
+</svg>

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -6,69 +6,22 @@
   <title>Datenschutzerklärung – IMHIS</title>
   <!-- Inter Font -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet" />
-  <style>
-    :root {
-      --font: "Inter", sans-serif;
-      --text: #1e293b;
-      --link: #2563eb;
-      --max: 800px;
-      --space: 1.5rem;
-    }
-    body {
-      font-family: var(--font);
-      color: var(--text);
-      line-height: 1.6;
-      max-width: var(--max);
-      margin: 2rem auto;
-      padding: 0 1rem;
-    }
-    h1 {
-      font-size: 2rem;
-      margin-bottom: var(--space);
-    }
-    h2 {
-      font-size: 1.5rem;
-      margin: 2rem 0 var(--space);
-    }
-    h3 {
-      font-size: 1.25rem;
-      margin: var(--space) 0 0.5rem;
-    }
-    h4 {
-      font-size: 1.1rem;
-      margin: var(--space) 0 0.5rem;
-    }
-    p, ul {
-      margin-bottom: var(--space);
-    }
-    ul {
-      padding-left: 1.25rem;
-    }
-    a {
-      color: var(--link);
-      text-decoration: none;
-    }
-    a:hover {
-      text-decoration: underline;
-    }
-    .section {
-      margin-top: 2rem;
-    }
-    .sub {
-      margin-left: 1rem;
-    }
-    .back-home {
-      display: inline-block;
-      margin-top: var(--space);
-      font-size: 0.9rem;
-    }
-    .back-home:hover {
-      text-decoration: underline;
-    }
-  </style>
+  <link rel="stylesheet" href="styles/main.css" />
 </head>
 <body>
+  <header>
+    <nav class="nav">
+      <h1 class="logo">IMHIS</h1>
+      <button class="nav-toggle" aria-label="Menü öffnen">☰</button>
+      <ul class="nav-links">
+        <li><a href="/index.html#instrument">Analyseinstrument</a></li>
+        <li><a href="/index.html#buch">Buch</a></li>
+        <li><a href="/index.html#kontakt">Analyse geplant?</a></li>
+      </ul>
+    </nav>
+  </header>
 
+  <main class="content">
   <section id="datenschutzerklaerung" class="section">
     <h1>Datenschutz­erklärung</h1>
 
@@ -365,5 +318,15 @@
 
   </section>
 
+  </main>
+
+  <footer id="kontakt">
+    <a href="mailto:florian.eisold@icloud.com" class="cta">Analyse geplant?</a>
+  </footer>
+  <footer class="section">
+    <a href="/impressum.html">Impressum</a>
+    <a href="/datenschutz.html">Datenschutz</a>
+  </footer>
+  <script src="scripts/nav.js"></script>
 </body>
 </html>

--- a/impressum.html
+++ b/impressum.html
@@ -9,69 +9,22 @@
 
     <!-- Schriftart -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet" />
-
-    <style>
-      :root {
-        --font-family: "Inter", sans-serif;
-        --color-text: #1e293b;
-        --color-primary: #0052a5;
-        --color-heading: #0f172a;
-        --color-link: #2563eb;
-        --max-width: 800px;
-        --spacing: 1.5rem;
-      }
-
-      body {
-        font-family: var(--font-family);
-        color: var(--color-text);
-        line-height: 1.6;
-        max-width: var(--max-width);
-        margin: 2rem auto;
-        padding: 0 1rem;
-      }
-
-      h1 {
-        font-size: 2rem;
-        color: var(--color-primary);
-        margin-bottom: var(--spacing);
-      }
-
-      h2 {
-        font-size: 1.25rem;
-        color: var(--color-heading);
-        margin: 2rem 0 0.5rem;
-      }
-
-      p, ul {
-        margin-bottom: var(--spacing);
-      }
-
-      a {
-        color: var(--color-link);
-        text-decoration: none;
-      }
-
-      a:hover {
-        text-decoration: underline;
-      }
-
-      .section {
-        margin-top: 2rem;
-      }
-
-      .back-home {
-        display: inline-block;
-        margin-top: var(--spacing);
-        font-size: 0.9rem;
-      }
-
-      .back-home:hover {
-        text-decoration: underline;
-      }
-    </style>
+    <link rel="stylesheet" href="styles/main.css" />
   </head>
-
   <body>
+    <header>
+      <nav class="nav">
+        <h1 class="logo">IMHIS</h1>
+        <button class="nav-toggle" aria-label="Menü öffnen">☰</button>
+        <ul class="nav-links">
+          <li><a href="/index.html#instrument">Analyseinstrument</a></li>
+          <li><a href="/index.html#buch">Buch</a></li>
+          <li><a href="/index.html#kontakt">Analyse geplant?</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main class="content">
     <h1>Impressum</h1>
 
     <section id="diensteanbieter" class="section">
@@ -191,5 +144,15 @@
     <p class="back-home">
       <a href="/index.html">← Zurück zur Startseite</a>
     </p>
+    </main>
+
+    <footer id="kontakt">
+      <a href="mailto:florian.eisold@icloud.com" class="cta">Analyse geplant?</a>
+    </footer>
+    <footer class="section">
+      <a href="/impressum.html">Impressum</a>
+      <a href="/datenschutz.html">Datenschutz</a>
+    </footer>
+    <script src="scripts/nav.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,77 +6,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet" />
-    <style>
-      :root {
-        --background: #f8fafc;
-        --primary: #0f172a;
-        --accent: #0052a5;
-        --link: #2563eb;
-        --light-gray: #e2e8f0;
-        --mid-gray: #94a3b8;
-        --box: #ffffff;
-        --text: #1e293b;
-      }
-      * { box-sizing: border-box; margin:0; padding:0; }
-      body { font-family: "Inter", sans-serif; background-color: var(--background); color: var(--text); line-height:1.6; }
-      header { background: var(--box); position:sticky; top:0; z-index:10; box-shadow:0 2px 8px rgba(0,0,0,0.05); }
-      .nav { max-width:960px; margin:0 auto; display:flex; justify-content:space-between; align-items:center; padding:1rem 2rem; }
-      .nav a { color: var(--primary); font-weight:600; text-decoration:none; margin-left:2rem; transition:color .2s; }
-      .nav a:hover { color: var(--accent); }
-      .hero {
-        position: relative;
-        text-align: center;
-        padding:6rem 2rem 4rem;
-        background: var(--light-gray);
-        overflow: hidden;
-      }
-      /* Hintergrund mit Herzschlag- und Datenlinien */
-      .hero::before {
-        content: '';
-        position: absolute;
-        top: 0; left: 50%; transform: translateX(-50%);
-        width: 120%; height: 120%;
-        background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200" viewBox="0 0 400 200"><polyline fill="none" stroke="%230052a5" stroke-width="2" points="0,100 50,100 70,60 90,140 110,100 150,100 170,80 190,120 210,100 260,100 300,150 340,50 380,100 400,100"/></svg>') no-repeat center;
-        opacity: 0.1;
-        pointer-events: none;
-      }
-      .hero h1 { position: relative; font-size:3rem; color: var(--accent); margin-bottom:0.5rem; }
-      /* Tagline stärker sichtbar */
-      .hero p.tagline { position: relative; font-size:1.3rem; font-weight:500; color: var(--primary); margin-bottom:2rem; }
-      .btn { position: relative; display:inline-block; background:var(--accent); color:#fff; padding:0.75rem 1.5rem; border-radius:8px; text-decoration:none; font-weight:600; transition:background .2s; }
-      .btn:hover { background:#003a75; }
-      .section { max-width:960px; margin:0 auto; padding:3rem 2rem; }
-      .section h2 { font-size:1.75rem; color: var(--primary); margin-bottom:1rem; }
-      .section p { font-size:1rem; margin-bottom:1.5rem; }
-      .feature-list { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:2rem; margin-top:2rem; }
-      .feature { background:var(--box); padding:1.5rem; border-radius:12px; box-shadow:0 4px 12px rgba(0,0,0,0.05); }
-      .feature h3 { font-size:1.25rem; margin-bottom:0.5rem; color:var(--accent); }
-      .feature p { font-size:0.95rem; color:var(--primary); }
-      .book-section { display:flex; flex-direction:column-reverse; gap:2rem; align-items:center; margin-top:2rem; }
-      .book-section img { max-width:260px; border-radius:12px; box-shadow:0 8px 24px rgba(0,0,0,0.08); }
-      .book-text { flex:1; max-width:600px; text-align:center; }
-      .book-links { display:flex; flex-wrap:wrap; gap:1rem; justify-content:center; margin-top:1rem; }
-      .book-links a { background:var(--accent); color:#fff; padding:0.6rem 1rem; border-radius:6px; font-weight:500; transition:background .2s; text-decoration:none; }
-      .book-links a:hover { background:#003a75; }
-      /* Call-to-Action Footer */
-      footer { text-align:center; padding:2rem 2rem 4rem; }
-      .cta { background:var(--accent); color:#fff; display:inline-block; padding:0.75rem 1.5rem; border-radius:8px; font-weight:600; text-decoration:none; transition:background .2s; }
-      .cta:hover { background:#003a75; }
-      @media(min-width:768px) {
-        .book-section { flex-direction:row; justify-content:center; align-items:flex-start; }
-        .book-text { text-align:left; }
-      }
-    </style>
+    <link rel="stylesheet" href="styles/main.css" />
   </head>
   <body>
     <header>
       <nav class="nav">
-        <h1 style="font-size:1.5rem;color:var(--primary)">IMHIS</h1>
-        <div>
-          <a href="#instrument">Analyseinstrument</a>
-          <a href="#buch">Buch</a>
-          <a href="#kontakt">Analyse geplant?</a>
-        </div>
+        <h1 class="logo">IMHIS</h1>
+        <button class="nav-toggle" aria-label="Menü öffnen">☰</button>
+        <ul class="nav-links">
+          <li><a href="#instrument">Analyseinstrument</a></li>
+          <li><a href="#buch">Buch</a></li>
+          <li><a href="#kontakt">Analyse geplant?</a></li>
+        </ul>
       </nav>
     </header>
 
@@ -97,26 +38,32 @@
       <h3>Dimensionen</h3>
       <div class="feature-list">
         <div class="feature">
+          <img src="assets/icons/workload.svg" alt="Icon Arbeitsbelastung" />
           <h3>Arbeitsbelastung</h3>
           <p>Messung der subjektiv empfundenen Arbeitsbelastung.</p>
         </div>
         <div class="feature">
+          <img src="assets/icons/satisfaction.svg" alt="Icon Nutzerzufriedenheit" />
           <h3>Nutzerzufriedenheit</h3>
           <p>Erhebung der Zufriedenheit mit dem Informationssystem.</p>
         </div>
         <div class="feature">
+          <img src="assets/icons/communication.svg" alt="Icon Kommunikation" />
           <h3>Kommunikation & Kollaboration</h3>
           <p>Analyse der Informationsflüsse durch intra- und interdisziplinären Kommunikation und Kollaboration.</p>
         </div>
         <div class="feature">
+          <img src="assets/icons/info-quality.svg" alt="Icon Informationsqualität" />
           <h3>Informationsqualität</h3>
           <p>Bewertung der Genauigkeit, Relevanz und Verständlichkeit der bereitgestellten Informationen.</p>
         </div>
         <div class="feature">
+          <img src="assets/icons/system-quality.svg" alt="Icon Systemqualität" />
           <h3>Systemqualität</h3>
           <p>Analyse der Zuverlässigkeit, Performance und Benutzerfreundlichkeit der Systeme.</p>
         </div>
         <div class="feature">
+          <img src="assets/icons/process.svg" alt="Icon Arbeitsprozesse" />
           <h3>Arbeitsprozesse</h3>
           <p>Untersuchung der Effizienz und Integration digitaler Systeme in klinische Abläufe.</p>
         </div>
@@ -152,5 +99,6 @@
       <a href="/impressum.html">Impressum</a>
       <a href="/datenschutz.html">Datenschutz</a>
     </footer>
+    <script src="scripts/nav.js"></script>
   </body>
 </html>

--- a/scripts/nav.js
+++ b/scripts/nav.js
@@ -1,0 +1,8 @@
+const toggle = document.querySelector('.nav-toggle');
+const links = document.querySelector('.nav-links');
+
+if (toggle && links) {
+  toggle.addEventListener('click', () => {
+    links.classList.toggle('open');
+  });
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,87 @@
+:root {
+  --background: #f8fafc;
+  --primary: #0f172a;
+  --accent: #0052a5;
+  --link: #2563eb;
+  --light-gray: #e2e8f0;
+  --mid-gray: #94a3b8;
+  --box: #ffffff;
+  --text: #1e293b;
+}
+
+* { box-sizing: border-box; margin:0; padding:0; }
+body {
+  font-family: "Inter", sans-serif;
+  background-color: var(--background);
+  color: var(--text);
+  line-height:1.6;
+}
+
+header { background: var(--box); position:sticky; top:0; z-index:10; box-shadow:0 2px 8px rgba(0,0,0,0.05); }
+.nav { max-width:960px; margin:0 auto; display:flex; justify-content:space-between; align-items:center; padding:1rem 2rem; }
+.logo { font-size:1.5rem; color:var(--primary); }
+.nav-toggle { display:none; background:none; border:none; font-size:1.5rem; }
+.nav-links { list-style:none; display:flex; }
+.nav-links li { margin-left:2rem; }
+.nav-links a { color: var(--primary); font-weight:600; text-decoration:none; transition:color .2s; }
+.nav-links a:hover { color: var(--accent); }
+
+@media(max-width:600px) {
+  .nav-toggle { display:block; }
+  .nav-links {
+    position:absolute; top:100%; right:0; background:var(--box);
+    flex-direction:column; align-items:flex-start;
+    padding:1rem 2rem; box-shadow:0 2px 8px rgba(0,0,0,0.05);
+    display:none;
+  }
+  .nav-links.open { display:flex; }
+  .nav-links li { margin:0 0 1rem 0; }
+}
+
+.hero { position: relative; text-align: center; padding:6rem 2rem 4rem; background:linear-gradient(135deg,var(--light-gray),var(--box)); overflow: hidden; }
+.hero h1 { position: relative; font-size:3rem; color: var(--accent); margin-bottom:0.5rem; }
+.hero p.tagline { position: relative; font-size:1.3rem; font-weight:500; color: var(--primary); margin-bottom:2rem; }
+.btn { position: relative; display:inline-block; background:var(--accent); color:#fff; padding:0.75rem 1.5rem; border-radius:8px; text-decoration:none; font-weight:600; transition:background .2s; }
+.btn:hover { background:#003a75; }
+
+.section { max-width:960px; margin:0 auto; padding:3rem 2rem; }
+.section h2 { font-size:1.75rem; color: var(--primary); margin-bottom:1rem; }
+.section p { font-size:1rem; margin-bottom:1.5rem; }
+
+.feature-list { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:2rem; margin-top:2rem; }
+.feature { background:var(--box); padding:1.5rem; border-radius:12px; box-shadow:0 4px 12px rgba(0,0,0,0.05); text-align:center; }
+.feature img { width:40px; height:40px; margin-bottom:1rem; }
+.feature h3 { font-size:1.25rem; margin-bottom:0.5rem; color:var(--accent); }
+.feature p { font-size:0.95rem; color:var(--primary); }
+
+.book-section { display:flex; flex-direction:column-reverse; gap:2rem; align-items:center; margin-top:2rem; }
+.book-section img { max-width:260px; border-radius:12px; box-shadow:0 8px 24px rgba(0,0,0,0.08); }
+.book-text { flex:1; max-width:600px; text-align:center; }
+.book-links { display:flex; flex-wrap:wrap; gap:1rem; justify-content:center; margin-top:1rem; }
+.book-links a { background:var(--accent); color:#fff; padding:0.6rem 1rem; border-radius:6px; font-weight:500; transition:background .2s; text-decoration:none; }
+.book-links a:hover { background:#003a75; }
+
+footer { text-align:center; padding:2rem 2rem 4rem; }
+.cta { background:var(--accent); color:#fff; display:inline-block; padding:0.75rem 1.5rem; border-radius:8px; font-weight:600; text-decoration:none; transition:background .2s; }
+.cta:hover { background:#003a75; }
+
+footer.section { background:var(--box); box-shadow:0 -2px 8px rgba(0,0,0,0.05); }
+footer.section a { margin:0 1rem; color:var(--primary); text-decoration:none; font-weight:500; }
+footer.section a:hover { color:var(--accent); }
+
+@media(min-width:768px) {
+  .book-section { flex-direction:row; justify-content:center; align-items:flex-start; }
+  .book-text { text-align:left; }
+}
+
+main.content { max-width:800px; margin:2rem auto; padding:0 1rem; }
+main.content h1 { font-size:2rem; margin-bottom:1.5rem; }
+main.content h2 { font-size:1.5rem; margin:2rem 0 1.5rem; }
+main.content h3 { font-size:1.25rem; margin:1.5rem 0 0.5rem; }
+main.content h4 { font-size:1.1rem; margin:1.5rem 0 0.5rem; }
+main.content p, main.content ul { margin-bottom:1.5rem; }
+main.content ul { padding-left:1.25rem; }
+main.content a { color: var(--link); text-decoration:none; }
+main.content a:hover { text-decoration:underline; }
+.back-home { display:inline-block; margin-top:1.5rem; font-size:0.9rem; }
+.back-home:hover { text-decoration:underline; }


### PR DESCRIPTION
## Summary
- extract shared styling into `styles/main.css` with theme variables, hero gradient and responsive layout
- add burger-menu navigation via `scripts/nav.js` and restructure pages to use it
- enhance feature cards with SVG icons and unify header/footer across subpages

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/IMHIS/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6894e678d1d48326b87839c0371d5529