### PR TITLE
Add cross-device favicons

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -7,6 +7,15 @@
   <!-- Inter Font -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles/main.css" />
+  <!-- Favicon & Touch Icons -->
+  <link rel="icon" href="/assets/icons/favicon.ico" sizes="any" />
+  <link rel="icon" type="image/svg+xml" href="/assets/icons/favicon.svg" />
+  <link
+    rel="apple-touch-icon"
+    sizes="180x180"
+    href="/assets/icons/apple-touch-icon.png"
+  />
+  <link rel="manifest" href="/assets/icons/site.webmanifest" />
 </head>
 <body>
   <header>

--- a/impressum.html
+++ b/impressum.html
@@ -10,6 +10,15 @@
     <!-- Schriftart -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="styles/main.css" />
+    <!-- Favicon & Touch Icons -->
+    <link rel="icon" href="/assets/icons/favicon.ico" sizes="any" />
+    <link rel="icon" type="image/svg+xml" href="/assets/icons/favicon.svg" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/assets/icons/apple-touch-icon.png"
+    />
+    <link rel="manifest" href="/assets/icons/site.webmanifest" />
   </head>
   <body>
     <header>

--- a/index.html
+++ b/index.html
@@ -17,18 +17,14 @@
     <link rel="stylesheet" href="styles/main.css" />
 
     <!-- Favicon & Touch Icons -->
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="96x96"
-      href="assets/icons/favicon-96x96.png"
-    />
+    <link rel="icon" href="/assets/icons/favicon.ico" sizes="any" />
+    <link rel="icon" type="image/svg+xml" href="/assets/icons/favicon.svg" />
     <link
       rel="apple-touch-icon"
       sizes="180x180"
-      href="assets/icons/apple-touch-icon.png"
+      href="/assets/icons/apple-touch-icon.png"
     />
-    <link rel="manifest" href="site.webmanifest" />
+    <link rel="manifest" href="/assets/icons/site.webmanifest" />
 
     <!-- (Optional) Safari Pinned Tab -->
     <!--


### PR DESCRIPTION
## Summary
- reference ico, svg, apple-touch icon and manifest so favicons display across devices
- remove root-level binary favicon fallback to comply with repository restrictions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895016d311483269bd1db1d20b92dda