### PR TITLE
Enhance background graphic visibility and replace header text with logo

### DIFF
--- a/assets/analysis-bg.svg
+++ b/assets/analysis-bg.svg
@@ -1,12 +1,12 @@
 <svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
-  <g stroke="#0052a5" stroke-opacity="0.15" stroke-width="2" fill="none">
-    <circle cx="200" cy="200" r="6" fill="#0052a5" fill-opacity="0.15" />
-    <circle cx="600" cy="150" r="6" fill="#0052a5" fill-opacity="0.15" />
-    <circle cx="1000" cy="300" r="6" fill="#0052a5" fill-opacity="0.15" />
-    <circle cx="1400" cy="250" r="6" fill="#0052a5" fill-opacity="0.15" />
-    <circle cx="400" cy="500" r="6" fill="#0052a5" fill-opacity="0.15" />
-    <circle cx="800" cy="550" r="6" fill="#0052a5" fill-opacity="0.15" />
-    <circle cx="1200" cy="600" r="6" fill="#0052a5" fill-opacity="0.15" />
+  <g stroke="#0052a5" stroke-opacity="0.3" stroke-width="2" fill="none">
+    <circle cx="200" cy="200" r="6" fill="#0052a5" fill-opacity="0.3" />
+    <circle cx="600" cy="150" r="6" fill="#0052a5" fill-opacity="0.3" />
+    <circle cx="1000" cy="300" r="6" fill="#0052a5" fill-opacity="0.3" />
+    <circle cx="1400" cy="250" r="6" fill="#0052a5" fill-opacity="0.3" />
+    <circle cx="400" cy="500" r="6" fill="#0052a5" fill-opacity="0.3" />
+    <circle cx="800" cy="550" r="6" fill="#0052a5" fill-opacity="0.3" />
+    <circle cx="1200" cy="600" r="6" fill="#0052a5" fill-opacity="0.3" />
     <line x1="200" y1="200" x2="600" y2="150" />
     <line x1="600" y1="150" x2="1000" y2="300" />
     <line x1="1000" y1="300" x2="1400" y2="250" />

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
   <body>
     <header>
       <nav class="nav">
-        <h1 class="logo">IMHIS<span class="slogan">Damit Digitalisierung wirkt</span></h1>
+        <h1 class="logo"><img src="assets/screenshot_432.png" alt="IMHIS Logo" /><span class="slogan">Damit Digitalisierung wirkt</span></h1>
         <button
           class="nav-toggle"
           aria-label="Menü öffnen"

--- a/styles/main.css
+++ b/styles/main.css
@@ -24,8 +24,8 @@ body {
 header { background: var(--box); position:sticky; top:0; z-index:10; box-shadow:0 2px 8px rgba(0,0,0,0.05); }
 .nav { max-width:960px; margin:0 auto; display:flex; justify-content:space-between; align-items:center; padding:1rem 2rem; }
 .logo { font-size:1.5rem; color:var(--primary); display:flex; align-items:baseline; gap:0.5rem; }
+.logo img { height:2rem; }
 .logo .slogan { font-size:0.9rem; font-weight:400; color:var(--mid-gray); }
-.logo .slogan::before { content:"–"; margin-right:0.25rem; }
 .nav-toggle { display:none; background:none; border:none; font-size:1.5rem; cursor:pointer; transition:color .2s; }
 .nav-toggle[aria-expanded="true"] { color: var(--accent); }
 .nav-links { list-style:none; display:flex; }
@@ -54,7 +54,7 @@ header { background: var(--box); position:sticky; top:0; z-index:10; box-shadow:
   width: 100%;
   height: 100%;
   background: url('../assets/analysis-bg.svg') center/cover no-repeat;
-  opacity: 0.25;
+  opacity: 0.4;
   z-index: 0;
 }
 .hero * { position: relative; z-index: 1; }


### PR DESCRIPTION
## Summary
- increase visibility of analysis background graphic and remove header dash
- replace header title text with `assets/screenshot_432.png` logo

## Testing
- `npx -y htmlhint index.html datenschutz.html impressum.html`
- `npx -y stylelint styles/main.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_6895e3b9676483269782c7be0e208e4f