### PR TITLE
fix header logo alignment on desktop

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -23,8 +23,8 @@ body {
 
 header { background: var(--box); position:sticky; top:0; z-index:10; box-shadow:0 2px 8px rgba(0,0,0,0.05); }
 .nav { max-width:960px; margin:0 auto; display:flex; justify-content:space-between; align-items:center; padding:1rem 2rem; }
-.logo { color: var(--primary); display: flex; align-items: center; gap: 0.5rem; line-height: 1; }
-.logo img { height: 0.9rem; }
+.logo { color: var(--primary); display: flex; align-items: center; gap: 0.5rem; line-height: 1; font-size:1rem; }
+.logo img { height: 1rem; display:block; }
 .logo .slogan { font-size:0.9rem; font-weight:400; color:var(--mid-gray); }
 .nav-toggle { display:none; background:none; border:none; font-size:1.5rem; cursor:pointer; transition:color .2s; }
 .nav-toggle[aria-expanded="true"] { color: var(--accent); }


### PR DESCRIPTION
## Summary
- Align header logo with slogan text on desktop by normalizing font and image sizes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ebd1c32c83268efb95966a225943