### PR TITLE
Enhance header logo and footer CTA styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,10 +39,10 @@
     />
     -->
   </head>
-  <body>
+  <body id="top">
     <header>
       <nav class="nav">
-        <h1 class="logo"><img src="assets/screenshot_432.png" alt="IMHIS Logo" /><span class="slogan">Damit Digitalisierung wirkt.</span></h1>
+        <a href="#top" class="logo"><img src="assets/screenshot_432.png" alt="IMHIS Logo" /><span class="slogan">Damit Digitalisierung wirkt.</span></a>
         <button
           class="nav-toggle"
           aria-label="Menü öffnen"

--- a/styles/main.css
+++ b/styles/main.css
@@ -23,8 +23,8 @@ body {
 
 header { background: var(--box); position:sticky; top:0; z-index:10; box-shadow:0 2px 8px rgba(0,0,0,0.05); }
 .nav { max-width:960px; margin:0 auto; display:flex; justify-content:space-between; align-items:center; padding:1rem 2rem; }
-.logo { color: var(--primary); display: flex; align-items: center; gap: 0.5rem; line-height: 1; font-size:1rem; }
-.logo img { height: 1rem; display:block; }
+.logo { color: var(--primary); display: flex; align-items: center; gap: 0.5rem; line-height: 1; font-size:1rem; text-decoration:none; }
+.logo img { height: 1.25rem; display:block; }
 .logo .slogan { font-size:0.9rem; font-weight:400; color:var(--mid-gray); }
 .nav-toggle { display:none; background:none; border:none; font-size:1.5rem; cursor:pointer; transition:color .2s; }
 .nav-toggle[aria-expanded="true"] { color: var(--accent); }
@@ -82,8 +82,8 @@ header { background: var(--box); position:sticky; top:0; z-index:10; box-shadow:
 .book-links a:hover { background:#003a75; transform:translateY(-2px); box-shadow:0 4px 12px rgba(0,0,0,0.15); }
 
 footer { text-align:center; padding:2rem 2rem 4rem; }
-.cta { background:var(--accent); color:#fff; display:inline-block; padding:0.75rem 1.5rem; border-radius:8px; font-weight:600; text-decoration:none; transition:background .2s, transform .2s, box-shadow .2s; }
-.cta:hover { background:#003a75; transform:translateY(-2px); box-shadow:0 4px 12px rgba(0,0,0,0.15); }
+.cta { background:var(--primary); color:#fff; display:inline-block; padding:0.75rem 1.5rem; border-radius:8px; font-weight:600; text-decoration:none; transition:background .2s, transform .2s, box-shadow .2s; }
+.cta:hover { background:#0d1b33; transform:translateY(-2px); box-shadow:0 4px 12px rgba(0,0,0,0.15); }
 
 footer.section { background:var(--box); box-shadow:0 -2px 8px rgba(0,0,0,0.05); }
 footer.section a { margin:0 1rem; color:var(--primary); text-decoration:none; font-weight:500; }


### PR DESCRIPTION
## Summary
- Make header logo and slogan a link to the top of the homepage
- Slightly enlarge logo and remove text decoration for cleaner look
- Restyle footer "Analyse geplant?" button to stand out from purchase links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895f8548db08326a5745e028011b83a