### PR TITLE
Improve mobile layout and header claim styling

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -13,32 +13,193 @@ html {
   scroll-behavior: smooth;
 }
 
-* { box-sizing: border-box; margin:0; padding:0; }
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
 body {
   font-family: "Inter", sans-serif;
   background-color: var(--background);
   color: var(--text);
-  line-height:1.6;
+  line-height: 1.6;
 }
 
-header { 
-  background: var(--box); 
-  position:sticky; 
-  top:0; 
-  z-index:10; 
-  box-shadow:0 2px 8px rgba(0,0,0,0.05); 
+/* Header */
+header {
+  background: var(--box);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
-.nav { 
-  max-width:960px; 
-  margin:0 auto; 
-  display:flex; 
-  justify-content:space-between; 
-  align-items:center; 
-  padding:1rem 2rem; 
+.nav {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  position: relative;
 }
 
-/* LOGO + CLAIM */
-.logo { 
-  color: var(--primary); 
-  d
+/* Logo & Claim */
+.logo {
+  display: flex;
+  align-items: center;
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.logo img {
+  height: 40px;
+}
+
+.claim {
+  margin-left: 0.5rem;
+  font-size: 0.8rem;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* Navigation links */
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+}
+
+.nav-links a {
+  text-decoration: none;
+  color: var(--link);
+  font-weight: 500;
+}
+
+.nav-toggle {
+  display: none;
+  font-size: 1.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+/* Hero */
+.hero {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+.hero .subtitle {
+  color: var(--mid-gray);
+  margin-bottom: 0.5rem;
+}
+
+.hero .tagline {
+  margin-bottom: 1.5rem;
+}
+
+.btn {
+  display: inline-block;
+  background: var(--accent);
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+/* Sections */
+.section {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 4rem 1rem;
+}
+
+.feature-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.feature img {
+  height: 40px;
+  margin-bottom: 1rem;
+}
+
+.book-section {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+}
+
+.book-section img {
+  max-width: 260px;
+  height: auto;
+}
+
+.book-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin-top: 1rem;
+}
+
+.book-links a {
+  color: var(--link);
+}
+
+/* Footer */
+footer {
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+footer.section {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .claim { font-size: 0.7rem; }
+  .nav {
+    padding: 0.5rem 1rem;
+  }
+
+  .nav-links {
+    flex-direction: column;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background: var(--box);
+    width: 100%;
+    display: none;
+    padding: 1rem 0;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  }
+
+  .nav-links.open {
+    display: flex;
+  }
+
+  .nav-links li {
+    text-align: center;
+    padding: 0.5rem 0;
+  }
+
+  .nav-toggle {
+    display: block;
+  }
+
+  .book-section {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .book-section img {
+    max-width: 200px;
+  }
+}


### PR DESCRIPTION
## Summary
- Rebuild stylesheet to restore missing rules and improve responsive design
- Align the "Damit Digitalisierung wirkt." claim with the logo and reduce its size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a2c670484832685b399e7980919f7