### PR TITLE
Highlight Dimensionen section and modernize book preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,8 +69,10 @@
         evidenzbasierte Insights direkt von den Anwender:innen – für Entscheidungen,
         die wirklich zählen.
       </p>
+    </section>
 
-      <h3>Dimensionen</h3>
+    <section class="section dimensionen-section" id="dimensionen">
+      <h2>Dimensionen</h2>
       <div class="feature-list">
         <div class="feature">
           <img src="assets/icons/workload.svg" alt="Icon Arbeitsbelastung" />
@@ -156,7 +158,16 @@
           >
         </div>
       </div>
-      <img src="9783658491895-3.tif" alt="Buchcover: Digitale Systeme – echte Wirkung" />
+      <a
+        href="https://link.springer.com/book/9783658491895"
+        target="_blank"
+        class="book-cover-link"
+      >
+        <img
+          src="9783658491895-3.tif"
+          alt="Buchcover: Digitale Systeme – echte Wirkung"
+        />
+      </a>
     </section>
 
     <footer id="kontakt">

--- a/styles/main.css
+++ b/styles/main.css
@@ -158,6 +158,16 @@ header {
   padding: 4rem 1rem;
 }
 
+.dimensionen-section {
+  background: var(--accent);
+  color: #fff;
+}
+
+.dimensionen-section h2 {
+  text-align: center;
+  color: #fff;
+}
+
 .feature-list {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
@@ -172,6 +182,7 @@ header {
   border: 1px solid var(--light-gray);
   border-radius: 8px;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
+  color: var(--text);
 }
 
 .feature:hover {
@@ -194,6 +205,13 @@ header {
 .book-section img {
   max-width: 260px;
   height: auto;
+  border-radius: 8px;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.book-cover-link:hover img {
+  transform: scale(1.05);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
 }
 
 .book-links {
@@ -210,14 +228,16 @@ header {
   padding: 0.5rem 1rem;
   background: var(--accent);
   color: #fff;
-  border-radius: 4px;
+  border-radius: 8px;
   text-decoration: none;
-  transition: background 0.3s, transform 0.2s;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  transition: background 0.3s, transform 0.2s, box-shadow 0.2s;
 }
 
 .book-links .buy-btn:hover {
   background: var(--link);
   transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 /* Footer */


### PR DESCRIPTION
## Summary
- Separate Dimensionen into its own accented section for clearer visual hierarchy
- Polish book links with rounded corners, shadows, and hover effects
- Wrap book cover with Springer link and scale animation on hover

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a38264a4c8326a709a5ecc0c8499d