### PR TITLE
Refine footer styling and layout

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -333,12 +333,14 @@
     </section>
   </main>
 
-  <footer id="kontakt">
+  <footer id="kontakt" class="contact-footer">
     <a href="mailto:florian.eisold@icloud.com" class="cta">Analyse geplant?</a>
   </footer>
-  <footer class="section">
-    <a href="/impressum.html">Impressum</a>
-    <a href="/datenschutz.html">Datenschutz</a>
+  <footer class="legal-footer">
+    <div class="legal-links">
+      <a href="/impressum.html">Impressum</a>
+      <a href="/datenschutz.html">Datenschutz</a>
+    </div>
   </footer>
 
   <script src="scripts/nav.js"></script>

--- a/impressum.html
+++ b/impressum.html
@@ -130,13 +130,15 @@
       </p>
     </main>
 
-    <footer id="kontakt">
+    <footer id="kontakt" class="contact-footer">
       <a href="mailto:florian.eisold@icloud.com" class="cta">Analyse geplant?</a>
     </footer>
 
-    <footer class="section">
-      <a href="/impressum.html">Impressum</a>
-      <a href="/datenschutz.html">Datenschutz</a>
+    <footer class="legal-footer">
+      <div class="legal-links">
+        <a href="/impressum.html">Impressum</a>
+        <a href="/datenschutz.html">Datenschutz</a>
+      </div>
     </footer>
 
     <script src="scripts/nav.js"></script>

--- a/index.html
+++ b/index.html
@@ -205,16 +205,18 @@
       </a>
     </section>
 
-    <footer id="kontakt">
+    <footer id="kontakt" class="contact-footer">
       <a href="mailto:florian.eisold@icloud.com" class="cta"
         >Analyse geplant?</a
       >
     </footer>
 
     <!-- Rechtliches -->
-    <footer class="section">
-      <a href="/impressum.html">Impressum</a>
-      <a href="/datenschutz.html">Datenschutz</a>
+    <footer class="legal-footer">
+      <div class="legal-links">
+        <a href="/impressum.html">Impressum</a>
+        <a href="/datenschutz.html">Datenschutz</a>
+      </div>
     </footer>
 
     <script src="scripts/nav.js"></script>

--- a/styles/main.css
+++ b/styles/main.css
@@ -38,12 +38,33 @@ a {
 footer {
   text-align: center;
   padding: 2rem 1rem;
-  background: var(--accent-light);
   border-top: 1px solid var(--light-gray);
 }
 
 footer a {
   color: var(--accent);
+}
+
+.contact-footer {
+  background: var(--accent-light);
+}
+
+.legal-footer {
+  background: var(--background);
+  padding: 1rem 0;
+}
+
+.legal-footer .legal-links {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.legal-footer a {
+  color: var(--mid-gray);
+  font-size: 0.875rem;
 }
 
 /* Header */
@@ -354,29 +375,20 @@ header {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
-footer.section {
-  display: flex;
-  justify-content: center;
-  gap: 1rem;
-}
-
 /* CTA email button */
 .cta {
   display: inline-block;
   padding: 0.75rem 1.5rem;
-  border: 2px solid var(--accent);
-  color: var(--accent);
+  background: var(--accent);
+  color: #fff;
   border-radius: 4px;
   text-decoration: none;
   font-weight: 600;
-  transition:
-    background 0.3s,
-    color 0.3s;
+  transition: background 0.3s;
 }
 
 .cta:hover {
-  background: var(--accent);
-  color: #fff;
+  background: var(--primary);
 }
 
 /* Responsive */


### PR DESCRIPTION
## Summary
- Split footer into contact and legal sections with distinct styling and full-width background.
- Highlighted email call-to-action while muting Impressum/Datenschutz links.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b247e223c832690baa080a44cb712