### PR TITLE
Add responsive benefits block under hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,27 @@
       <a href="#instrument" class="btn">Mehr erfahren</a>
     </section>
 
+    <section class="benefits-block" aria-label="Vorteile">
+      <div class="benefit-item">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M5 13l4 4L19 7" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+        <span>Kostenlos</span>
+      </div>
+      <div class="benefit-item">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M5 13l4 4L19 7" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+        <span>Wissenschaftlich fundiert</span>
+      </div>
+      <div class="benefit-item">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M5 13l4 4L19 7" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+        <span>Praxisnah</span>
+      </div>
+    </section>
+
     <section class="section" id="instrument">
       <h2>Ein Analyseinstrument für echten digitalen Fortschritt</h2>
       <p>

--- a/styles/main.css
+++ b/styles/main.css
@@ -456,3 +456,55 @@ header {
     padding: 2rem 1rem;
   }
 }
+
+/* Benefits Block */
+.benefits-block {
+  max-width: 960px;
+  margin: 2rem auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+}
+
+.benefits-block .benefit-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  font-family: "Inter", sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #172554;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.05), rgba(23, 37, 84, 0.05));
+  border: 1px solid rgba(23, 37, 84, 0.15);
+  border-radius: 14px;
+  box-shadow: 0 2px 4px rgba(23, 37, 84, 0.08);
+}
+
+.benefits-block .benefit-item svg {
+  flex-shrink: 0;
+}
+
+.benefits-block .benefit-item:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: -1rem;
+  transform: translateY(-50%);
+  width: 1px;
+  height: 60%;
+  background: rgba(23, 37, 84, 0.15);
+}
+
+@media (max-width: 640px) {
+  .benefits-block {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .benefits-block .benefit-item:not(:last-child)::after {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add three-item benefits block showcasing Kostenlos, Wissenschaftlich fundiert, Praxisnah below the hero section
- style benefits with Inter font, new primary/accent colors, subtle gradient, borders, shadows and responsive layout with hairline dividers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b785b30088326b0d897b63b46d505