### PR TITLE
Move 'Mehr erfahren' link below benefits block

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,8 +81,9 @@
         </svg>
         <span>Praxisnah</span>
       </div>
-        <a href="#instrument" class="btn">Mehr erfahren</a>
     </section>
+
+    <a href="#instrument" class="btn">Mehr erfahren</a>
 
     <section class="section" id="instrument">
       <h2>Ein Analyseinstrument für echten digitalen Fortschritt</h2>


### PR DESCRIPTION
## Summary
- Relocate the "Mehr erfahren" button to appear below the benefits block and link to the instrument section.

## Testing
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_689b7ae077948326be7c86a57eab7e82