### PR TITLE
Refine header layout and mobile menu

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -98,7 +98,7 @@ footer a {
   width: 100%;
   height: var(--header-h);
   z-index: 100;
-  background: transparent;
+  background: rgba(255, 255, 255, 0.96);
   transition:
     background 0.25s ease,
     backdrop-filter 0.25s ease,
@@ -108,24 +108,22 @@ footer a {
 }
 
 .site-header.is-scrolled {
-  background: rgba(23, 37, 84, 0.92);
   backdrop-filter: blur(6px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(23, 37, 84, 0.08);
   height: calc(var(--header-h) * 0.9);
 }
 
 .site-header.on-light {
-  background: rgba(255, 255, 255, 0.96);
   border-bottom: 1px solid rgba(23, 37, 84, 0.08);
 }
 
 .site-nav {
-  max-width: 1200px;
+  max-width: 960px;
   margin: 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 2rem;
+  padding: 0 1rem;
   height: 100%;
 }
 
@@ -214,9 +212,9 @@ footer a {
     top: var(--header-h);
     left: 0;
     right: 0;
-    background: rgba(23, 37, 84, 0.92);
+    background: rgba(255, 255, 255, 0.96);
     backdrop-filter: blur(6px);
-    transform: translateY(-100%);
+    transform: translateY(calc(-100% - var(--header-h)));
     transition: transform 0.25s ease;
     flex-direction: column;
     height: calc(100dvh - var(--header-h));
@@ -228,7 +226,7 @@ footer a {
   }
 
   .mobile-drawer .nav-link {
-    color: #fff;
+    color: var(--primary);
     display: block;
     padding: 0.75rem 1rem;
     min-height: 44px;
@@ -236,7 +234,7 @@ footer a {
 
   .mobile-drawer .nav-link:hover,
   .mobile-drawer .nav-link:focus {
-    color: #2563eb;
+    color: var(--link);
   }
 }
 
@@ -250,7 +248,7 @@ footer a {
 .hero {
   position: relative;
   text-align: center;
-  padding: 4rem 1rem 2rem;
+  padding: calc(var(--header-h) + 2rem) 1rem 2rem;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- remove blue header bar and align navigation with page width
- hide mobile drawer off-screen and lighten menu styling
- add top padding to hero section to avoid logo overlap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b95c79c148326ad42fafb32a4a205