### PR TITLE
Add responsive book pre-order section

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,24 +236,50 @@
               <span>Evidenzbasierte Empfehlungen</span>
             </li>
           </ul>
-          <div class="book-cta">
-            <a
-              href="https://link.springer.com/book/9783658491895"
-              target="_blank"
-              rel="noopener"
-              class="btn-primary"
-              >Jetzt vorbestellen</a
-            >
-            <a
-              href="https://link.springer.com/book/9783658491895#about"
-              target="_blank"
-              rel="noopener"
-              class="btn-secondary"
-              >Mehr zum Buch</a
-            >
-            <span class="trust-badge"
-              ><span class="dot"></span>Wissenschaftlich fundiert • Evidenzbasiert</span
-            >
+          <div class="book-order">
+            <div class="order-buttons">
+              <a
+                href="https://link.springer.com/book/9783658491895"
+                target="_blank"
+                rel="noopener"
+                class="btn-primary"
+                >Jetzt vorbestellen</a
+              >
+              <button
+                type="button"
+                class="btn-secondary"
+                id="toggle-sellers"
+              >
+                Weitere Händler anzeigen
+              </button>
+            </div>
+            <ul class="seller-list" id="seller-list">
+              <li>
+                <a href="https://www.amazon.de/" target="_blank" rel="noopener"
+                  >Amazon</a
+                >
+              </li>
+              <li>
+                <a href="https://www.thalia.de/" target="_blank" rel="noopener"
+                  >Thalia</a
+                >
+              </li>
+              <li>
+                <a href="https://www.hugendubel.de/" target="_blank" rel="noopener"
+                  >Hugendubel</a
+                >
+              </li>
+              <li>
+                <a href="https://www.beck-shop.de/" target="_blank" rel="noopener"
+                  >Beck</a
+                >
+              </li>
+              <li>
+                <a href="https://www.lehmanns.de/" target="_blank" rel="noopener"
+                  >Lehmanns</a
+                >
+              </li>
+            </ul>
           </div>
         </div>
         <div class="book-cover">
@@ -283,5 +309,10 @@
     </footer>
 
     <script src="scripts/nav.js" defer></script>
+    <script>
+      document.getElementById('toggle-sellers').addEventListener('click', function () {
+        document.getElementById('seller-list').classList.toggle('open');
+      });
+    </script>
   </body>
 </html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -411,64 +411,83 @@ header {
   flex-shrink: 0;
 }
 
-.book-cta {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem;
+.book-section .book-order {
+  margin-top: 1.5rem;
 }
 
-.btn-primary,
-.btn-secondary {
+.book-section .order-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.book-section .order-buttons .btn-primary,
+.book-section .order-buttons .btn-secondary {
+  flex: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.625rem 1.25rem;
+  padding: 0.75rem 1.5rem;
   font-weight: 600;
-  border-radius: 999px;
+  border-radius: 8px;
   text-decoration: none;
   transition: background 0.3s, color 0.3s, border-color 0.3s, box-shadow 0.3s;
 }
 
-.btn-primary {
+.book-section .order-buttons .btn-primary {
   background: #2563eb;
   color: #fff;
-  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.35);
+  box-shadow: 0 2px 4px rgba(37, 99, 235, 0.2);
 }
 
-.btn-primary:hover {
+.book-section .order-buttons .btn-primary:hover {
   background: #1e4fd1;
 }
 
-.btn-secondary {
+.book-section .order-buttons .btn-secondary {
   background: #fff;
   color: #172554;
-  border: 1px solid rgba(23, 37, 84, 0.2);
+  border: 1px solid #ccc;
 }
 
-.btn-secondary:hover {
+.book-section .order-buttons .btn-secondary:hover {
   color: #2563eb;
   border-color: #2563eb;
 }
 
-.book-cta a:focus-visible {
-  outline: 2px solid #2563eb;
-  outline-offset: 2px;
+.book-section .seller-list {
+  list-style: none;
+  margin-top: 1rem;
+  padding: 0;
+  display: none;
 }
 
-.trust-badge {
-  display: flex;
-  align-items: center;
-  gap: 0.375rem;
-  color: #17255499;
-  font-size: 0.875rem;
+.book-section .seller-list.open {
+  display: block;
 }
 
-.trust-badge .dot {
-  width: 6px;
-  height: 6px;
-  background: #2563eb;
-  border-radius: 50%;
+.book-section .seller-list li + li {
+  margin-top: 0.5rem;
+}
+
+.book-section .seller-list a {
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.book-section .seller-list a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .book-section .order-buttons {
+    flex-direction: column;
+  }
+
+  .book-section .order-buttons .btn-primary,
+  .book-section .order-buttons .btn-secondary {
+    width: 100%;
+  }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Replace old book call-to-action with responsive order area
- Add vendor toggle list and styled buttons for pre-ordering
- Provide simple JavaScript toggle for vendor list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c77e924888326b613d13c7ad142f0