### PR TITLE
Improve seller list and button styling

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -440,9 +440,9 @@ header {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.75rem 1.5rem;
+  padding: 0.625rem 1.25rem;
   font-weight: 600;
-  border-radius: 8px;
+  border-radius: 999px;
   text-decoration: none;
   transition: background 0.3s, color 0.3s, border-color 0.3s, box-shadow 0.3s;
   font-size: 1rem;
@@ -451,8 +451,6 @@ header {
 .book-section .order-buttons .btn-primary {
   background: #2563eb;
   color: #fff;
-  padding: 0.625rem 1.25rem;
-  border-radius: 999px;
   box-shadow: 0 6px 16px rgba(37, 99, 235, 0.35);
 }
 
@@ -462,13 +460,13 @@ header {
 
 .book-section .order-buttons .btn-secondary {
   background: #fff;
-  color: #172554;
-  border: 1px solid #ccc;
+  color: #2563eb;
+  border: 1px solid #2563eb;
+  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.15);
 }
 
 .book-section .order-buttons .btn-secondary:hover {
-  color: #2563eb;
-  border-color: #2563eb;
+  background: #e6eef7;
 }
 
 .book-section .trust-badge {
@@ -479,7 +477,7 @@ header {
   padding: 0.4rem 0.8rem;
   font-size: 0.875rem;
   color: rgba(23, 37, 84, 0.85);
-  background: rgba(23, 37, 84, 0.08);
+  background: transparent;
   border-radius: 999px;
   width: fit-content;
   transition: box-shadow 0.3s;
@@ -515,11 +513,22 @@ header {
 }
 
 .book-section .seller-list a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.625rem 1.25rem;
+  background: #fff;
   color: #2563eb;
+  border: 1px solid #2563eb;
+  border-radius: 999px;
+  font-weight: 600;
   text-decoration: none;
+  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.15);
+  transition: background 0.3s, color 0.3s, border-color 0.3s, box-shadow 0.3s;
 }
 
 .book-section .seller-list a:hover {
+  background: #e6eef7;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary
- Restyle secondary action buttons to mirror the primary button with a white background
- Remove background from trust badge for a cleaner appearance
- Turn seller list links into pill-shaped buttons matching site design

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c8a8fd1f4832697256293712b1d3a