### PR TITLE
Align instrument section styling with dimensionen design

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -794,18 +794,23 @@ header {
 
 /* ===== Instrument (agency-grade, matched to Book/Dimensionen) ===== */
 /* Shell & Layout */
-.section.instrument-pro .instrument-outer { max-width: 1200px; margin: 0 auto; }
-.section.instrument-pro .instrument-inner {
-  max-width: 720px;                 /* fokussierte Lesespalte wie in der Vorschau */
-  margin: 0 auto;
-  text-align: left;
-  background:
-    radial-gradient(circle at 22% 8%, rgba(37,99,235,0.045), transparent 65%),
-    #fff;                           /* dezente Surface wie Book/Dimensionen */
+.section.instrument-pro .instrument-outer {
+  max-width: 1200px;
+  margin: 0 auto 1.25rem;
+  background: radial-gradient(circle at 20% 20%, rgba(37,99,235,0.08), transparent 70%), #fff;
   border: 1px solid rgba(23,37,84,0.10);
   border-radius: 20px;
-  box-shadow: 0 6px 24px rgba(23,37,84,0.05);
-  padding: clamp(1.5rem, 3vw, 2rem) clamp(1.25rem, 3vw, 1.75rem);
+  box-shadow: 0 8px 40px rgba(23,37,84,0.08);
+  padding: 3rem 1.5rem;
+  font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+}
+@media (min-width:1024px){
+  .section.instrument-pro .instrument-outer{ padding:4rem 2rem; margin-bottom:1.5rem; }
+}
+.section.instrument-pro .instrument-inner {
+  max-width: 720px;
+  margin: 0 auto;
+  text-align: left;
 }
 
 /* Typografie */
@@ -819,42 +824,38 @@ header {
 }
 .section.instrument-pro h2{
   color: #172554;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: -.01em;
-  font-size: clamp(1.6rem, 2.4vw, 2rem);
-  margin: .2rem 0 .6rem 0;
+  font-size: clamp(1.6rem, 2.2vw, 2rem);
+  margin: 0 0 .6rem 0;
 }
 .section.instrument-pro .lead{
-  color: #1e293b;
-  font-size: clamp(1.05rem, 1.15vw, 1.125rem);
-  line-height: 1.7;
+  color: #172554cc;
+  font-size: clamp(1rem, 1.2vw, 1.125rem);
+  line-height: 1.6;
   margin: 0 0 .6rem 0;
 }
 .section.instrument-pro .lead .emph{ color: #172554; font-weight: 700; }
 .section.instrument-pro .body{
-  color: #334155;
-  font-size: clamp(1rem, 1.05vw, 1.06rem);
-  line-height: 1.7;
+  color: #475569;
+  font-size: .98rem;
+  line-height: 1.55;
   margin: 0;
 }
 .section.instrument-pro .accent-text{ color: #2563eb; font-weight: 600; }
 
 /* Weiche optische Übergänge oben/unten */
 .section.instrument-pro .instrument-bridge{
-  height: 16px;
-  opacity: .6;
-  margin: 10px 0;
-  background: transparent;
+  height: 14px;
+  opacity: .55;
+  pointer-events: none;
 }
 .section.instrument-pro .instrument-bridge--top{
-  background: radial-gradient(70% 140% at 50% 0%, rgba(37,99,235,.06), transparent 70%);
+  margin: .35rem 0 0;
+  background: radial-gradient(60% 160% at 20% 0%, rgba(37,99,235,.06), transparent 70%);
 }
 .section.instrument-pro .instrument-bridge--bottom{
-  background: radial-gradient(70% 140% at 50% 100%, rgba(37,99,235,.07), transparent 70%);
-}
-
-/* Mobile Fine‑Tune */
-@media (max-width: 640px){
-  .section.instrument-pro .instrument-inner { padding: 1.25rem 1rem; }
+  margin: 1.25rem 0 0;
+  background: radial-gradient(80% 140% at 50% 100%, rgba(37,99,235,.08), transparent 70%);
 }
 


### PR DESCRIPTION
## Summary
- Style `instrument-pro` section like `dimensionen-section` with shared width, background, and typography.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cb4cc05788326b5d08de1f59f086c