### PR TITLE
Enhance SEO metadata and mobile rendering

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -5,6 +5,10 @@
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <meta name="description" content="Datenschutzerklärung des Projekts IMHIS" />
       <title>Datenschutzerklärung – IMHIS</title>
+      <meta name="robots" content="noindex,nofollow" />
+      <meta name="author" content="Florian Eisold" />
+      <meta name="theme-color" content="#0f172a" />
+      <link rel="canonical" href="https://imhis.de/datenschutz.html" />
       <!-- Inter Font -->
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap"
@@ -39,6 +43,8 @@
               alt="IMHIS Logo"
               decoding="async"
               fetchpriority="high"
+              width="398"
+              height="74"
             />
         </a>
         <button

--- a/impressum.html
+++ b/impressum.html
@@ -7,6 +7,9 @@
       <title>Impressum – IMHIS</title>
       <!-- Nicht in Suchmaschinen indexieren -->
       <meta name="robots" content="noindex,nofollow" />
+      <meta name="author" content="Florian Eisold" />
+      <meta name="theme-color" content="#0f172a" />
+      <link rel="canonical" href="https://imhis.de/impressum.html" />
 
     <!-- Schriftart -->
     <link
@@ -43,6 +46,8 @@
               alt="IMHIS Logo"
               decoding="async"
               fetchpriority="high"
+              width="398"
+              height="74"
             />
         </a>
         <button

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       content="Gesundheitsinformationssysteme, digitale Medizin, Analyseinstrument"
     />
     <meta name="robots" content="index, follow" />
+    <meta name="author" content="Florian Eisold" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="canonical" href="https://imhis.de/" />
     <meta
@@ -29,7 +30,18 @@
       property="og:image"
       content="https://imhis.de/9783658491895-3.jpeg"
     />
+    <meta property="og:site_name" content="IMHIS" />
     <meta property="og:locale" content="de_DE" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "IMHIS – Impact Monitor for Health Information Systems",
+        "url": "https://imhis.de/",
+        "logo": "https://imhis.de/assets/Logo_blau.svg"
+      }
+    </script>
 
     <!-- Google Fonts Preconnect -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -70,6 +82,8 @@
             alt="IMHIS Logo"
             decoding="async"
             fetchpriority="high"
+            width="398"
+            height="74"
           />
         </a>
         <button

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
 Disallow: /impressum.html
+Disallow: /datenschutz.html
 
 Sitemap: https://imhis.de/site-map.xml


### PR DESCRIPTION
## Summary
- add author, Open Graph site name, and JSON-LD organization metadata
- define dimensions for header logo and unify theme color on legal pages
- block legal pages from indexing via meta tags and robots.txt

## Testing
- `npx --yes htmlhint index.html`
- `npx htmlhint impressum.html datenschutz.html`

------
https://chatgpt.com/codex/tasks/task_e_689cc8821bb4832689732a6b43403055