### PR TITLE
Align instrument section with other site blocks

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -797,7 +797,7 @@ header {
 /* Shell & Layout */
 .section.instrument-pro .instrument-outer {
   max-width: 1200px;
-  margin: 0 auto 0.75rem;
+  margin: 0 auto 1.25rem;
   background: radial-gradient(circle at 20% 20%, rgba(37,99,235,0.08), transparent 70%), #fff;
   border: 1px solid rgba(23,37,84,0.10);
   border-radius: 20px;
@@ -806,10 +806,10 @@ header {
   font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
 }
 @media (min-width:1024px){
-  .section.instrument-pro .instrument-outer{ padding:4rem 2rem; margin-bottom:1rem; }
+  .section.instrument-pro .instrument-outer{ padding:4rem 2rem; margin-bottom:1.5rem; }
 }
 .section.instrument-pro .instrument-inner {
-  max-width: 720px;
+  max-width: 100%;
   margin: 0 auto;
   text-align: left;
 }
@@ -827,7 +827,7 @@ header {
 /* Ensure eyebrow labels are uniform across sections */
 .section.dimensionen-section .eyebrow,
 .section.book-section .eyebrow{
-  font-size: .8rem;
+  font-size: .8rem !important;
 }
 .section.instrument-pro h2{
   color: #172554;


### PR DESCRIPTION
## Summary
- Make the instrument section use the same width as the dimensions and book sections
- Match vertical spacing between instrument and dimensions to the spacing between dimensions and book
- Set Analysedimensionen and Buch eyebrow fonts to the same size as Analyseinstrument

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ccbab6a9883269262caa04afeb10b