### PR TITLE
Align header logo with content width and widen instrument section

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -95,12 +95,12 @@ header {
 }
 
 .nav {
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem;
+  padding: 1rem 1.5rem 1rem 0;
   position: relative;
   border-bottom: 1px solid var(--light-gray);
 }
@@ -278,6 +278,11 @@ header {
   max-width: 960px;
   margin: 0 auto;
   padding: 4rem 1rem;
+}
+
+.section.instrument-pro {
+  max-width: 100%;
+  padding: 0;
 }
 
 .section h2 {


### PR DESCRIPTION
## Summary
- Align header navigation container with dimensionen section and remove left padding so the logo matches the section's left edge
- Override base section styles for instrument section so it spans same width as dimensionen

## Testing
- `npx prettier --check styles/main.css` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf288f748326b3a18cf823ce9b6d