### PR TITLE
Improve navigation menu event handling

### DIFF
--- a/scripts/nav.js
+++ b/scripts/nav.js
@@ -2,38 +2,38 @@ const toggle = document.querySelector(".nav-toggle");
 const links = document.querySelector(".nav-links");
 
 if (toggle && links) {
-  const linkItems = links.querySelectorAll("a");
-
-  const toggleMenu = () => {
+  function toggleMenu() {
     const open = links.classList.toggle("open");
     toggle.setAttribute("aria-expanded", open);
     toggle.classList.toggle("open", open);
     toggle.setAttribute("aria-label", open ? "Menü schließen" : "Menü öffnen");
-  };
+
+    if (open) {
+      document.addEventListener("click", closeOnOutsideClick);
+      document.addEventListener("keydown", closeOnEscape);
+    } else {
+      document.removeEventListener("click", closeOnOutsideClick);
+      document.removeEventListener("keydown", closeOnEscape);
+    }
+  }
+
+  function closeOnOutsideClick(e) {
+    if (!links.contains(e.target) && !toggle.contains(e.target)) {
+      toggleMenu();
+    }
+  }
+
+  function closeOnEscape(e) {
+    if (e.key === "Escape") {
+      toggleMenu();
+    }
+  }
 
   toggle.addEventListener("click", toggleMenu);
 
-  document.addEventListener("click", (e) => {
-    if (
-      links.classList.contains("open") &&
-      !links.contains(e.target) &&
-      !toggle.contains(e.target)
-    ) {
+  links.addEventListener("click", (e) => {
+    if (e.target.matches("a") && links.classList.contains("open")) {
       toggleMenu();
     }
   });
-
-  document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape" && links.classList.contains("open")) {
-      toggleMenu();
-    }
-  });
-
-    linkItems.forEach((link) =>
-      link.addEventListener("click", () => {
-        if (links.classList.contains("open")) {
-          toggleMenu();
-        }
-      })
-    );
 }


### PR DESCRIPTION
## Summary
- optimize nav menu by adding and removing document event listeners only when the menu is open
- reduce multiple link listeners with event delegation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cdf29f890832696030a990f5c6ed0