### PR TITLE
Improve legal page performance and spacing

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -10,10 +10,12 @@
       <meta name="theme-color" content="#0f172a" />
       <link rel="canonical" href="https://imhis.de/datenschutz.html" />
       <!-- Inter Font -->
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap"
-      rel="stylesheet"
-    />
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap"
+        rel="stylesheet"
+      />
       <link rel="preload" href="styles/main.css" as="style" />
       <link rel="stylesheet" href="styles/main.css" />
 

--- a/impressum.html
+++ b/impressum.html
@@ -12,12 +12,14 @@
       <link rel="canonical" href="https://imhis.de/impressum.html" />
 
     <!-- Schriftart -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap"
       rel="stylesheet"
     />
-      <link rel="preload" href="styles/main.css" as="style" />
-      <link rel="stylesheet" href="styles/main.css" />
+    <link rel="preload" href="styles/main.css" as="style" />
+    <link rel="stylesheet" href="styles/main.css" />
 
     <!-- Preload header logo to improve load time -->
     <link

--- a/styles/main.css
+++ b/styles/main.css
@@ -886,6 +886,10 @@ header {
 }
 
 /* Legal pages (Impressum & Datenschutz) */
+.legal-content .section {
+  padding: 2rem 1rem;
+}
+
 .legal-content h1 {
   color: var(--primary);
   font-size: clamp(1.75rem, 3vw, 2.25rem);
@@ -910,13 +914,15 @@ header {
 }
 
 .legal-content p {
-  margin-bottom: 1rem;
+  margin-bottom: 1.25rem;
+  line-height: 1.7;
 }
 
 .legal-content ul,
 .legal-content ol {
-  margin: 0 0 1rem 1.25rem;
+  margin: 0 0 1.25rem 1.25rem;
   padding-left: 1.25rem;
+  line-height: 1.7;
 }
 
 .legal-content a {


### PR DESCRIPTION
## Summary
- add preconnect hints for Google Fonts on datenschutz and impressum pages to speed up font loading
- refine legal page spacing for paragraphs, lists, and sections for improved readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ce324b19883268b42be45faa02286