### PR TITLE
Link book cover to Springer with hover effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,16 +360,22 @@
           </div>
         </div>
         <div class="book-cover">
-          <picture>
-            <img
-              src="9783658491895-3.jpeg"
-              alt="Buchcover: Digitale Systeme – echte Wirkung"
-              loading="lazy"
-              width="827"
-              height="1173"
-              decoding="async"
-            />
-          </picture>
+          <a
+            href="https://link.springer.com/book/9783658491895"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <picture>
+              <img
+                src="9783658491895-3.jpeg"
+                alt="Buchcover: Digitale Systeme – echte Wirkung"
+                loading="lazy"
+                width="827"
+                height="1173"
+                decoding="async"
+              />
+            </picture>
+          </a>
         </div>
       </div>
         </section>

--- a/styles/main.css
+++ b/styles/main.css
@@ -420,6 +420,10 @@ header {
   order: 2;
 }
 
+.book-cover a {
+  display: block;
+}
+
 .book-cover picture,
 .book-cover img {
   width: 100%;
@@ -428,6 +432,13 @@ header {
   border-radius: 16px;
   border: 1px solid rgba(23, 37, 84, 0.1);
   box-shadow: 0 8px 40px rgba(23, 37, 84, 0.06);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.book-cover a:hover img,
+.book-cover a:focus img {
+  transform: scale(1.03);
+  box-shadow: 0 12px 48px rgba(23, 37, 84, 0.12);
 }
 
 .book-info h2 {


### PR DESCRIPTION
## Summary
- Link homepage book cover to the Springer page.
- Add hover/focus transition for the book cover image.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dbd538c188326b2d9bace7eecfef3