### PR TITLE
Align legal text with header logo

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -915,6 +915,9 @@ header {
 }
 
 /* Legal pages (Impressum & Datenschutz) */
+.legal-content {
+  max-width: 1200px;
+}
 .legal-content .section {
   padding: 2rem 1rem;
 }


### PR DESCRIPTION
## Summary
- Expand legal page layout to 1200px to line up text with header logo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dbfc6e6048326acbd9e7a4f6881db