### PR TITLE
Hide unwanted button behind book cover

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -424,7 +424,10 @@ header {
   display: block;
 }
 
-.book-cover picture,
+.book-cover picture {
+  display: block;
+}
+
 .book-cover img {
   width: 100%;
   height: auto;


### PR DESCRIPTION
## Summary
- avoid stray button appearing behind the book cover image by styling only the image and keeping the `picture` container invisible

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dc21296608326b97d9e11a19da877