### PR TITLE
feat: deepen book cover shadow

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -435,16 +435,16 @@ header {
   aspect-ratio: 3 / 4;
   border-radius: 16px;
   border: 1px solid rgba(23, 37, 84, 0.1);
-  box-shadow: 8px 0 15px rgba(23, 37, 84, 0.1),
-    0 8px 15px rgba(23, 37, 84, 0.1);
+  box-shadow: 12px 0 25px rgba(23, 37, 84, 0.15),
+    0 12px 25px rgba(23, 37, 84, 0.15);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .book-cover a:hover img,
 .book-cover a:focus img {
   transform: scale(1.03);
-  box-shadow: 12px 0 24px rgba(23, 37, 84, 0.15),
-    0 12px 24px rgba(23, 37, 84, 0.15);
+  box-shadow: 16px 0 32px rgba(23, 37, 84, 0.2),
+    0 16px 32px rgba(23, 37, 84, 0.2);
 }
 
 .book-info h2 {


### PR DESCRIPTION
## Summary
- intensify default book cover box-shadow for greater depth
- increase hover/focus shadow to emphasize interaction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dd29c5bac832695d72ced9775b862