### PR TITLE
Use header logo for social media previews

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -9,6 +9,25 @@
       <meta name="author" content="Florian Eisold" />
       <meta name="theme-color" content="#0f172a" />
       <link rel="canonical" href="https://imhis.de/datenschutz.html" />
+
+      <meta property="og:title" content="Datenschutzerklärung – IMHIS" />
+      <meta
+        property="og:description"
+        content="Datenschutzerklärung des Projekts IMHIS"
+      />
+      <meta property="og:url" content="https://imhis.de/datenschutz.html" />
+      <meta property="og:type" content="website" />
+      <meta
+        property="og:image"
+        content="https://imhis.de/assets/Logo_blau.svg"
+      />
+      <meta property="og:site_name" content="IMHIS" />
+      <meta property="og:locale" content="de_DE" />
+      <meta name="twitter:card" content="summary" />
+      <meta
+        name="twitter:image"
+        content="https://imhis.de/assets/Logo_blau.svg"
+      />
       <!-- Inter Font -->
       <link rel="preconnect" href="https://fonts.googleapis.com" />
       <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/impressum.html
+++ b/impressum.html
@@ -11,6 +11,22 @@
       <meta name="theme-color" content="#0f172a" />
       <link rel="canonical" href="https://imhis.de/impressum.html" />
 
+      <meta property="og:title" content="Impressum – IMHIS" />
+      <meta property="og:description" content="Impressum der Website IMHIS" />
+      <meta property="og:url" content="https://imhis.de/impressum.html" />
+      <meta property="og:type" content="website" />
+      <meta
+        property="og:image"
+        content="https://imhis.de/assets/Logo_blau.svg"
+      />
+      <meta property="og:site_name" content="IMHIS" />
+      <meta property="og:locale" content="de_DE" />
+      <meta name="twitter:card" content="summary" />
+      <meta
+        name="twitter:image"
+        content="https://imhis.de/assets/Logo_blau.svg"
+      />
+
     <!-- Schriftart -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/index.html
+++ b/index.html
@@ -29,7 +29,12 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:image"
-      content="https://imhis.de/9783658491895-3.jpeg"
+      content="https://imhis.de/assets/Logo_blau.svg"
+    />
+    <meta name="twitter:card" content="summary" />
+    <meta
+      name="twitter:image"
+      content="https://imhis.de/assets/Logo_blau.svg"
     />
     <meta property="og:site_name" content="IMHIS" />
     <meta property="og:locale" content="de_DE" />


### PR DESCRIPTION
## Summary
- show the header logo when the site is shared on social networks
- add Open Graph and Twitter card metadata to legal pages

## Testing
- `npx --yes htmlhint index.html impressum.html datenschutz.html`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f1a96e2c08326b8e8577bf7995d7a