### PR TITLE
Serve SVG favicon for Google search preview

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -46,8 +46,8 @@
       type="image/svg+xml"
     />
     <!-- Favicon & Touch Icons -->
-    <link rel="icon" href="/assets/icons/favicon.ico" sizes="any" />
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.svg" />
     <link
       rel="apple-touch-icon"
       sizes="180x180"

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" width="83.782158" height="71.462448"><svg viewBox="0 0 83.78216 71.462449" shape-rendering="geometricPrecision" text-rendering="geometricPrecision" version="1.1" id="SvgjsSvg1017" sodipodi:docname="imhis_eye_symbol.svg" width="83.782158" height="71.462448" inkscape:export-filename="../Documents/00_IMHIS_Logo/Documents/00_IMHIS_Logo/Neu_neu/imhis_eye_symbol.svg" inkscape:export-xdpi="96" inkscape:export-ydpi="96" inkscape:version="1.4.2 (ebf0e940, 2025-05-08)" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview id="SvgjsSodipodi:namedview1016" pagecolor="#ffffff" bordercolor="#000000" borderopacity="0.25" inkscape:showpageshadow="2" inkscape:pageopacity="0.0" inkscape:pagecheckerboard="0" inkscape:deskcolor="#d1d1d1" inkscape:export-bgcolor="#aaaaaaa0" inkscape:zoom="3.0701112" inkscape:cx="10.260215" inkscape:cy="44.786652" inkscape:window-width="1440" inkscape:window-height="900" inkscape:window-x="0" inkscape:window-y="0" inkscape:window-maximized="0" inkscape:current-layer="svg5"></sodipodi:namedview>
+  <defs id="SvgjsDefs1015">
+    <style id="SvgjsStyle1014">
+      .icon-stroke { stroke: #172554; stroke-width: 12; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+      .accent-stroke { stroke: #2563eb; stroke-width: 10; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+      .navy-fill { fill: #172554; }
+    </style>
+  </defs>
+  <!-- Eye outline -->
+  <!-- Inner chart line -->
+  <!-- Data nodes -->
+  <path d="M 76.726341,26.05801" style="fill:none;stroke:#2563eb;stroke-width:14;stroke-linecap:round;stroke-linejoin:round" id="SvgjsPath1013"></path>
+  <path id="SvgjsPath1012" style="fill:#254c90;stroke-width:0.192759" class="accent-fill" d="M 0,0.01849 H 8.916763 V 71.43632 H 0 Z"></path>
+  <path id="SvgjsPath1011" style="fill:#254c90;stroke-width:0.163995" class="accent-fill" d="M 81.62045,19.73439 A 7.2098037,7.2805561 0 0 1 74.91,25.23145 v 46.19879 h 8.91637 V 19.73439 Z"></path>
+  <path class="accent" d="m 26.442611,67.23238 -10e-4,-2.63985 0.005,-43.11213 0.005,-5.76022 20.89151,26.97146 28.11378,-34.44693" id="SvgjsPath1010" sodipodi:nodetypes="cccccc" style="fill:none;stroke:#254c90;stroke-width:8.45694;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"></path>
+  <path id="SvgjsPath1009" style="fill:#254c90;stroke-width:0.661919" class="accent-fill" d="M 83.782161,7.28055 A 7.2816004,7.2805561 0 0 1 76.500551,14.5611 7.2816004,7.2805561 0 0 1 69.218951,7.28055 7.2816004,7.2805561 0 0 1 76.500551,0 7.2816004,7.2805561 0 0 1 83.782161,7.28055 Z"></path>
+</svg><style>@media (prefers-color-scheme: light) { :root { filter: none; } }
+@media (prefers-color-scheme: dark) { :root { filter: none; } }
+</style></svg>

--- a/impressum.html
+++ b/impressum.html
@@ -46,8 +46,8 @@
     />
 
     <!-- Favicon & Touch Icons -->
-    <link rel="icon" href="/assets/icons/favicon.ico" sizes="any" />
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.svg" />
     <link
       rel="apple-touch-icon"
       sizes="180x180"

--- a/index.html
+++ b/index.html
@@ -70,8 +70,8 @@
     />
 
     <!-- Favicon & Touch Icons -->
-    <link rel="icon" href="/assets/icons/favicon.ico" sizes="any" />
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.svg" />
     <link
       rel="apple-touch-icon"
       sizes="180x180"


### PR DESCRIPTION
## Summary
- Remove binary `favicon.ico` that caused unsupported file error
- Reference root `favicon.svg` in all pages, including shortcut icon link

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f2272906083269daa836f167c5209