### PR TITLE
Add book CTA to benefits block

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,7 +238,10 @@
       </div>
     </section>
 
-    <a href="#instrument" class="btn">Mehr erfahren</a>
+    <div class="benefits-actions">
+      <a href="#instrument" class="cta">Mehr erfahren</a>
+      <a href="#buch" class="cta">Buch ansehen</a>
+    </div>
 
     <!-- Instrument – aligned to Book & Dimensionen -->
 <section class="section instrument-pro" id="instrument" aria-labelledby="instrument-title">

--- a/styles/main.css
+++ b/styles/main.css
@@ -290,24 +290,6 @@ header {
   color: var(--mid-gray);
 }
 
-.btn {
-  display: block;
-  width: max-content;
-  margin: 2rem auto;
-  background: var(--accent);
-  color: #fff;
-  padding: 0.75rem 1.25rem;
-  border-radius: 8px;
-  text-decoration: none;
-  transition:
-    background 0.3s,
-    transform 0.2s;
-}
-
-.btn:hover {
-  background: var(--link);
-  transform: translateY(-2px);
-}
 
 /* Sections */
 .section {
@@ -716,6 +698,20 @@ header {
   align-items: center;
   gap: 1rem;
   flex-direction: column;
+}
+
+.benefits-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+@media (min-width: 601px) {
+  .benefits-actions {
+    flex-direction: row;
+    justify-content: center;
+  }
 }
 
 .benefits-block .benefit-item {


### PR DESCRIPTION
## Summary
- add "Buch ansehen" call-to-action alongside benefits block button
- restyle benefits block buttons to match footer CTA
- drop unused `.btn` styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f2a959c108326b2aaf81799574abc