### PR TITLE
Align language buttons and enlarge header navigation text

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,10 +119,12 @@
                 <span class="lang lang-en" hidden>Planning an assessment?</span>
               </a>
             </li>
-            <li>
-              <button id="language-toggle" class="lang-btn" aria-label="English">
-                <img src="assets/icons/flag-gb.svg" alt="English" class="lang lang-de" />
-                <img src="assets/icons/flag-de.svg" alt="Deutsch" class="lang lang-en" hidden />
+            <li class="lang-switcher">
+              <button class="lang-btn" data-lang="de" aria-label="Deutsch">
+                <img src="assets/icons/flag-de.svg" alt="Deutsch" />
+              </button>
+              <button class="lang-btn" data-lang="en" aria-label="English">
+                <img src="assets/icons/flag-gb.svg" alt="English" />
               </button>
             </li>
           </ul>

--- a/scripts/lang.js
+++ b/scripts/lang.js
@@ -1,4 +1,4 @@
-const langButton = document.getElementById("language-toggle");
+const langButtons = document.querySelectorAll(".lang-btn");
 
 function setLanguage(lang) {
   const english = lang === "en";
@@ -11,9 +11,10 @@ function setLanguage(lang) {
     el.hidden = !english;
   });
 
-  if (langButton) {
-    langButton.setAttribute("aria-label", english ? "Deutsch" : "English");
-  }
+  langButtons.forEach((btn) => {
+    const isActive = btn.dataset.lang === lang;
+    btn.setAttribute("aria-pressed", isActive);
+  });
 
   const navToggle = document.querySelector(".nav-toggle");
   if (navToggle) {
@@ -35,9 +36,10 @@ function setLanguage(lang) {
   });
 }
 
-langButton?.addEventListener("click", () => {
-  const newLang = document.documentElement.lang === "de" ? "en" : "de";
-  setLanguage(newLang);
+langButtons.forEach((btn) => {
+  btn.addEventListener("click", () => {
+    setLanguage(btn.dataset.lang);
+  });
 });
 
 setLanguage("de");

--- a/styles/main.css
+++ b/styles/main.css
@@ -165,6 +165,7 @@ header {
     text-decoration: none;
     color: var(--primary);
     font-weight: 500;
+    font-size: 1.125rem;
     padding: 0.25rem 0;
     transition: color 0.3s ease;
     background: none;
@@ -202,6 +203,12 @@ header {
 .nav-links li {
   text-align: center;
   padding: 0.5rem 0;
+}
+
+.lang-switcher {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
 }
 
   .nav-links a:hover::after,


### PR DESCRIPTION
## Summary
- Replace single language toggle with side-by-side German and English buttons
- Increase header navigation link font size for better visibility
- Adjust scripts and styles to support new language switcher layout

## Testing
- `npx htmlhint *.html`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f4595f5a88326a7e50edf129246ec