### PR TITLE
Improve mobile navigation and responsiveness

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -76,7 +76,7 @@
         >
           <span class="hamburger"></span>
         </button>
-        <ul class="nav-links" id="nav-links">
+        <ul class="nav-links" id="nav-links" hidden>
           <li><a href="/index.html#instrument">Analyseinstrument</a></li>
           <li><a href="/index.html#buch">Buch</a></li>
           <li><a href="/index.html#kontakt">Analyse geplant?</a></li>

--- a/impressum.html
+++ b/impressum.html
@@ -76,7 +76,7 @@
         >
           <span class="hamburger"></span>
         </button>
-        <ul class="nav-links" id="nav-links">
+        <ul class="nav-links" id="nav-links" hidden>
           <li><a href="/index.html#instrument">Analyseinstrument</a></li>
           <li><a href="/index.html#buch">Buch</a></li>
           <li><a href="/index.html#kontakt">Analyse geplant?</a></li>

--- a/scripts/nav.js
+++ b/scripts/nav.js
@@ -39,6 +39,29 @@ if (toggle && links) {
     }
   }
 
+  const mq = window.matchMedia("(min-width: 768px)");
+
+  function syncNav(e) {
+    if (e.matches) {
+      links.hidden = false;
+      links.classList.remove("open");
+      toggle.classList.remove("open");
+      toggle.setAttribute("aria-expanded", "false");
+      document.removeEventListener("click", closeOnOutsideClick);
+      document.removeEventListener("keydown", closeOnEscape);
+    } else {
+      links.hidden = true;
+      links.classList.remove("open");
+      toggle.classList.remove("open");
+      toggle.setAttribute("aria-expanded", "false");
+      document.removeEventListener("click", closeOnOutsideClick);
+      document.removeEventListener("keydown", closeOnEscape);
+    }
+  }
+
+  syncNav(mq);
+  mq.addEventListener("change", syncNav);
+
   toggle.addEventListener("click", toggleMenu);
   updateAriaLabel(false);
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -300,14 +300,14 @@ header {
 .hero .tagline {
   margin-top: 0;
   margin-bottom: 0.75rem;
-  font-size: 1.5rem;
+  font-size: clamp(1.25rem, 6vw, 1.5rem);
   font-weight: 600;
   color: var(--primary);
 }
 
 .hero .subtagline {
   margin-bottom: 2rem;
-  font-size: 1.125rem;
+  font-size: clamp(1rem, 4.5vw, 1.125rem);
   color: var(--mid-gray);
 }
 
@@ -418,6 +418,12 @@ header {
   grid-template-columns: 1fr;
   gap: 2rem;
   align-items: center;
+}
+
+@media (min-width: 768px) {
+  .book-content {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 .book-info {


### PR DESCRIPTION
## Summary
- Scale hero tagline and subtagline with `clamp()` for smoother mobile typography.
- Introduce tablet breakpoint and two-column layout for book section.
- Sync navigation visibility with viewport width and hide menus initially on legal pages.

## Testing
- `npx -y htmlhint index.html datenschutz.html impressum.html`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f4704b20883269078e898de917985