### PR TITLE
Add fallback favicon for better search preview

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -57,15 +57,16 @@
       as="image"
       type="image/svg+xml"
     />
-    <!-- Favicon & Touch Icons -->
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="shortcut icon" href="/favicon.svg" />
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="/assets/icons/apple-touch-icon.png"
-    />
-    <link rel="manifest" href="/assets/icons/site.webmanifest" />
+      <!-- Favicon & Touch Icons -->
+      <link rel="icon" href="/assets/icons/favicon.ico" sizes="any" />
+      <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+      <link rel="shortcut icon" href="/assets/icons/favicon.ico" />
+      <link
+        rel="apple-touch-icon"
+        sizes="180x180"
+        href="/assets/icons/apple-touch-icon.png"
+      />
+      <link rel="manifest" href="/assets/icons/site.webmanifest" />
   </head>
   <body id="top">
     <a class="skip-link" href="#main-content">

--- a/impressum.html
+++ b/impressum.html
@@ -57,15 +57,16 @@
       type="image/svg+xml"
     />
 
-    <!-- Favicon & Touch Icons -->
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="shortcut icon" href="/favicon.svg" />
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="/assets/icons/apple-touch-icon.png"
-    />
-    <link rel="manifest" href="/assets/icons/site.webmanifest" />
+      <!-- Favicon & Touch Icons -->
+      <link rel="icon" href="/assets/icons/favicon.ico" sizes="any" />
+      <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+      <link rel="shortcut icon" href="/assets/icons/favicon.ico" />
+      <link
+        rel="apple-touch-icon"
+        sizes="180x180"
+        href="/assets/icons/apple-touch-icon.png"
+      />
+      <link rel="manifest" href="/assets/icons/site.webmanifest" />
   </head>
   <body id="top">
     <a class="skip-link" href="#main-content">

--- a/index.html
+++ b/index.html
@@ -105,15 +105,16 @@
       fetchpriority="high"
     />
 
-    <!-- Favicon & Touch Icons -->
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="shortcut icon" href="/favicon.svg" />
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="/assets/icons/apple-touch-icon.png"
-    />
-    <link rel="manifest" href="/assets/icons/site.webmanifest" />
+      <!-- Favicon & Touch Icons -->
+      <link rel="icon" href="/assets/icons/favicon.ico" sizes="any" />
+      <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+      <link rel="shortcut icon" href="/assets/icons/favicon.ico" />
+      <link
+        rel="apple-touch-icon"
+        sizes="180x180"
+        href="/assets/icons/apple-touch-icon.png"
+      />
+      <link rel="manifest" href="/assets/icons/site.webmanifest" />
   </head>
     <body id="top">
       <a class="skip-link" href="#main-content">


### PR DESCRIPTION
## Summary
- reference existing `assets/icons/favicon.ico` from HTML instead of adding a new root file
- keep SVG and manifest links for broad favicon support

## Testing
- `npx --yes htmlhint *.html`


------
https://chatgpt.com/codex/tasks/task_e_68a065c4402c8326a874c04880fa6297