### PR TITLE
Remove body top id to reduce layout shift

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -68,7 +68,7 @@
       />
       <link rel="manifest" href="/assets/icons/site.webmanifest" />
   </head>
-  <body id="top">
+  <body>
     <a class="skip-link" href="#main-content">
       <span class="lang lang-de">Zum Inhalt springen</span>
       <span class="lang lang-en" hidden>Skip to content</span>

--- a/impressum.html
+++ b/impressum.html
@@ -68,7 +68,7 @@
       />
       <link rel="manifest" href="/assets/icons/site.webmanifest" />
   </head>
-  <body id="top">
+  <body>
     <a class="skip-link" href="#main-content">
       <span class="lang lang-de">Zum Inhalt springen</span>
       <span class="lang lang-en" hidden>Skip to content</span>

--- a/index.html
+++ b/index.html
@@ -116,8 +116,9 @@
       />
       <link rel="manifest" href="/assets/icons/site.webmanifest" />
   </head>
-    <body id="top">
-      <a class="skip-link" href="#main-content">
+  <body>
+    <div id="top"></div>
+    <a class="skip-link" href="#main-content">
         <span class="lang lang-de">Zum Inhalt springen</span>
         <span class="lang lang-en" hidden>Skip to content</span>
       </a>


### PR DESCRIPTION
## Summary
- remove `id="top"` from body tags to avoid layout shift
- add dedicated `#top` anchor in index page for back-to-top links

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a84330ec832689aab92d026cb799