### PR TITLE
Reduce layout shifts from web fonts

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -39,7 +39,15 @@
       <link rel="preconnect" href="https://fonts.googleapis.com" />
       <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
       <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap"
+        rel="preload"
+        as="font"
+        href="https://fonts.gstatic.com/s/inter/v19/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2"
+        type="font/woff2"
+        crossorigin
+        fetchpriority="high"
+      />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=optional"
         rel="stylesheet"
       />
       <link

--- a/impressum.html
+++ b/impressum.html
@@ -38,7 +38,15 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap"
+      rel="preload"
+      as="font"
+      href="https://fonts.gstatic.com/s/inter/v19/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2"
+      type="font/woff2"
+      crossorigin
+      fetchpriority="high"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=optional"
       rel="stylesheet"
     />
     <link

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
       fetchpriority="high"
     />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=optional"
       rel="stylesheet"
     />
 


### PR DESCRIPTION
## Summary
- Preload Inter web font on all pages
- Use optional font display to minimize layout shifts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1aa8e5dd483268953a0849e660539