### PR TITLE
Update header navigation to News and link to LinkedIn

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -119,9 +119,9 @@
             </a>
           </li>
           <li>
-            <a href="/index.html#kontakt">
-              <span class="lang lang-de">Kontakt</span>
-              <span class="lang lang-en" hidden>Contact</span>
+            <a href="/index.html#linkedin">
+              <span class="lang lang-de">News</span>
+              <span class="lang lang-en" hidden>News</span>
             </a>
           </li>
           <li class="lang-switcher">

--- a/impressum.html
+++ b/impressum.html
@@ -119,9 +119,9 @@
             </a>
           </li>
           <li>
-            <a href="/index.html#kontakt">
-              <span class="lang lang-de">Kontakt</span>
-              <span class="lang lang-en" hidden>Contact</span>
+            <a href="/index.html#linkedin">
+              <span class="lang lang-de">News</span>
+              <span class="lang lang-en" hidden>News</span>
             </a>
           </li>
           <li class="lang-switcher">

--- a/index.html
+++ b/index.html
@@ -165,9 +165,9 @@
       </a>
     </li>
     <li>
-      <a href="#kontakt">
-        <span class="lang lang-de">Kontakt</span>
-        <span class="lang lang-en" hidden>Contact</span>
+      <a href="#linkedin">
+        <span class="lang lang-de">News</span>
+        <span class="lang lang-en" hidden>News</span>
       </a>
     </li>
 


### PR DESCRIPTION
## Summary
- Rename header link from Kontakt to News
- Point News link to LinkedIn section across pages

## Testing
- `npx --yes htmlhint index.html datenschutz.html impressum.html`

------
https://chatgpt.com/codex/tasks/task_e_68a1c84a286c83268a017abfe26c076c