### PR TITLE
Align Datenschutz page width with header

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -61,7 +61,6 @@
         .legal-content {
           font-family: "Inter", system-ui, sans-serif;
           line-height: 1.6;
-          max-width: 70ch;
           margin: 0 auto;
           padding: 2rem 1rem;
         }


### PR DESCRIPTION
## Summary
- Remove restrictive max-width on the Datenschutzerklärung content container to match the site header width

## Testing
- `npx --yes htmlhint datenschutz.html`

------
https://chatgpt.com/codex/tasks/task_e_68a1e1d710b883269560a1c156a74cb2