### PR TITLE
Fix LinkedIn news section to show all posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,7 +524,7 @@
     <li data-li-url="https://www.linkedin.com/posts/imhis_klinikalltag-imhis-digitalhealth-activity-7358774831888146433-ip7L"></li>
     <li data-li-url="https://www.linkedin.com/posts/imhis_imhis-gesundheitswesen-klinikalltag-activity-7356227941107654657-r4So"></li>
     <li data-li-url="https://www.linkedin.com/posts/imhis_klinikalltag-digitalisierung-imhis-activity-7353735926637817858-lo3H"></li>
-    <li data-li-url="hhttps://www.linkedin.com/posts/imhis_bundeswehr-gesundheitsversorgung-baesrokratie-activity-7348255311322923008-7YQj"></li>
+    <li data-li-url="https://www.linkedin.com/posts/imhis_bundeswehr-gesundheitsversorgung-baesrokratie-activity-7348255311322923008-7YQj"></li>
   </ul>
 
   <!-- Stream -->
@@ -808,8 +808,8 @@
   }
   function readUrls(){
     return Array.from(liUrlList.querySelectorAll('[data-li-url]'))
-      .slice(0, 2)
-      .map(el => el.getAttribute('data-li-url')).filter(Boolean);
+      .map(el => el.getAttribute('data-li-url'))
+      .filter(Boolean);
   }
 
   // Fallback-Karte vor Consent


### PR DESCRIPTION
## Summary
- display all configured LinkedIn URLs instead of only first two
- correct malformed LinkedIn URL in post list

## Testing
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68a33f03c94883269de3004aa00a2abc