### PR TITLE
fix: reduce layout shifts by sizing feature icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,7 +568,13 @@
           </p>
           <ul class="book-features">
             <li>
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+              <svg
+                width="20"
+                height="20"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
                 <path d="M16.704 5.29a1 1 0 0 0-1.408-1.42L8 11.17 4.704 7.87a1 1 0 1 0-1.408 1.42l4 4a1 1 0 0 0 1.408 0l8-8z"/>
               </svg>
               <span>
@@ -577,7 +583,13 @@
               </span>
             </li>
             <li>
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+              <svg
+                width="20"
+                height="20"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
                 <path d="M16.704 5.29a1 1 0 0 0-1.408-1.42L8 11.17 4.704 7.87a1 1 0 1 0-1.408 1.42l4 4a1 1 0 0 0 1.408 0l8-8z"/>
               </svg>
               <span>
@@ -586,7 +598,13 @@
               </span>
             </li>
             <li>
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+              <svg
+                width="20"
+                height="20"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
                 <path d="M16.704 5.29a1 1 0 0 0-1.408-1.42L8 11.17 4.704 7.87a1 1 0 1 0-1.408 1.42l4 4a1 1 0 0 0 1.408 0l8-8z"/>
               </svg>
               <span>


### PR DESCRIPTION
## Summary
- specify width and height on book feature SVG icons to reserve space during load

## Testing
- `npx --yes htmlhint index.html datenschutz.html impressum.html`


------
https://chatgpt.com/codex/tasks/task_e_68a5bc1d0588832682d7d2760bc0d43f