### PR TITLE
Add English translations to pitch section

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,22 +387,30 @@
     <div class="instrument-bridge instrument-bridge--top" aria-hidden="true"></div>
 
     <div class="instrument-inner">
-      <p class="eyebrow">Echte digitale Wirkung</p>
-      <h2 id="pitch-title">Jede Software verspricht digitale Wirkung. IMHIS belegt sie.</h2>
+      <p class="eyebrow">
+        <span class="lang lang-de">Echte digitale Wirkung</span>
+        <span class="lang lang-en" hidden>Real digital impact</span>
+      </p>
+      <h2 id="pitch-title">
+        <span class="lang lang-de">Jede Software verspricht digitale Wirkung. IMHIS belegt sie.</span>
+        <span class="lang lang-en" hidden>Every software promises digital impact. IMHIS proves it.</span>
+      </h2>
       <p class="lead">
-        Mit IMHIS die Black Box des Klinikalltages öffnen – Schwächen erkennen, Stärken ausbauen, Wirkung sichern.
+        <span class="lang lang-de">Mit IMHIS die Black Box des Klinikalltages öffnen – Schwächen erkennen, Stärken ausbauen, Wirkung sichern.</span>
+        <span class="lang lang-en" hidden>With IMHIS you can open the black box of daily clinical routine—identify weaknesses, expand strengths, ensure impact.</span>
       </p>
 
       <!-- Analysebeispiel: digitale Patientenkurve (Badge) -->
-      <div class="analysis-badge" style="display:inline-flex;align-items:center;gap:0.5rem;background:rgba(37,88,235,0.05);border:0;border-radius:0.5rem;padding:0.5rem 0.9rem;margin-top:2rem;margin-bottom:1rem;font-size:1rem;font-weight:600;color:var(--accent);">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" color="var(--accent)">
-          <rect x="3" y="13" width="3" height="8" rx="0.6"></rect>
-          <rect x="8" y="9" width="3" height="12" rx="0.6"></rect>
-          <rect x="13" y="5" width="3" height="16" rx="0.6"></rect>
-          <rect x="18" y="3" width="3" height="18" rx="0.6"></rect>
-        </svg>
-        <span>Analysebeispiel: Digitale&nbsp;Patientenkurve</span>
-      </div>
+        <div class="analysis-badge" style="display:inline-flex;align-items:center;gap:0.5rem;background:rgba(37,88,235,0.05);border:0;border-radius:0.5rem;padding:0.5rem 0.9rem;margin-top:2rem;margin-bottom:1rem;font-size:1rem;font-weight:600;color:var(--accent);">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" color="var(--accent)">
+            <rect x="3" y="13" width="3" height="8" rx="0.6"></rect>
+            <rect x="8" y="9" width="3" height="12" rx="0.6"></rect>
+            <rect x="13" y="5" width="3" height="16" rx="0.6"></rect>
+            <rect x="18" y="3" width="3" height="18" rx="0.6"></rect>
+          </svg>
+          <span class="lang lang-de">Analysebeispiel: <strong>Digitale&nbsp;Patientenkurve</strong></span>
+          <span class="lang lang-en" hidden>Analysis example: <strong>digital patient curve</strong></span>
+        </div>
 
       <!-- Grid mit sechs Kennzahlen -->
       <div class="counter-wrapper" style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:2rem;margin:2rem 0 3rem;">
@@ -528,9 +536,10 @@
           <span class="lang lang-en">Reveal all effects now</span>
         </a>
 
-      <p class="footnote" style="margin-top:1rem;font-size:0.8rem;color:var(--text);">
-        *Beispielhafte Ergebnisse aus der Analyse der digitalen Patientenkurve M. der Firma M. an einem deutschen Universitätsklinikum
-      </p>
+        <p class="footnote" style="margin-top:1rem;font-size:0.8rem;color:var(--text);">
+          <span class="lang lang-de">*Beispielhafte Ergebnisse aus der Analyse der digitalen Patientenkurve M. der Firma M. an einem deutschen Universitätsklinikum</span>
+          <span class="lang lang-en" hidden>*Sample results from the analysis of the digital patient curve M. by company M. at a German university hospital</span>
+        </p>
     </div>
 
     <!-- Übergang zur nächsten Section -->


### PR DESCRIPTION
## Summary
- Provide full English translations for the pitch eyebrow, heading, lead and footnote.
- Add bilingual analysis badge and emphasize the digital patient curve.

## Testing
- `npx htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68af4e2012ec8326a824db069ac18571