### PR TITLE
reuse icons across pitch and analysis sections

### DIFF
--- a/assets/icons/system-quality.svg
+++ b/assets/icons/system-quality.svg
@@ -1,12 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#0052a5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <rect x="4" y="4" width="16" height="16" rx="2" ry="2"/>
-  <rect x="9" y="9" width="6" height="6"/>
-  <line x1="9" y1="1" x2="9" y2="4"/>
-  <line x1="15" y1="1" x2="15" y2="4"/>
-  <line x1="9" y1="20" x2="9" y2="23"/>
-  <line x1="15" y1="20" x2="15" y2="23"/>
-  <line x1="20" y1="9" x2="23" y2="9"/>
-  <line x1="20" y1="15" x2="23" y2="15"/>
-  <line x1="1" y1="9" x2="4" y2="9"/>
-  <line x1="1" y1="15" x2="4" y2="15"/>
+  <rect x="3" y="4" width="18" height="14" rx="2"></rect>
+  <line x1="8" y1="20" x2="16" y2="20"></line>
 </svg>

--- a/index.html
+++ b/index.html
@@ -436,10 +436,7 @@
         <!-- Card 2: Systemqualität (+49 %) -->
         <div class="counter-card" style="position:relative;background:linear-gradient(to bottom right,rgba(255,255,255,0.9),rgba(245,250,255,0.9));backdrop-filter:blur(12px);padding:1.75rem;border-radius:1rem;box-shadow:0 10px 24px rgba(0,0,0,0.07);text-align:center;">
           <div class="icon-wrapper" style="width:48px;height:48px;margin:0 auto 0.75rem auto;display:flex;align-items:center;justify-content:center;background:rgba(37,88,235,0.12);border-radius:50%;">
-            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" color="var(--accent)">
-              <rect x="3" y="4" width="18" height="14" rx="2"></rect>
-              <line x1="8" y1="20" x2="16" y2="20"></line>
-            </svg>
+            <img src="assets/icons/system-quality.svg" alt="Icon Systemqualität" data-alt-en="Icon System quality" width="28" height="28" decoding="async" loading="lazy" />
           </div>
           <div class="counter-number" data-target="49" data-unit="%" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:baseline;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
             <span class="prefix" style="font-size:1.8rem;line-height:1;"></span>
@@ -475,9 +472,7 @@
         <!-- Card 4: Kommunikation & Kollaboration (+3,1 %) -->
         <div class="counter-card" style="position:relative;background:linear-gradient(to bottom right,rgba(255,255,255,0.9),rgba(245,250,255,0.9));backdrop-filter:blur(12px);padding:1.75rem;border-radius:1rem;box-shadow:0 10px 24px rgba(0,0,0,0.07);text-align:center;">
           <div class="icon-wrapper" style="width:48px;height:48px;margin:0 auto 0.75rem auto;display:flex;align-items:center;justify-content:center;background:rgba(37,88,235,0.12);border-radius:50%;">
-            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" color="var(--accent)">
-              <path d="M21 15v-8a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h4l4 3 4-3h2a2 2 0 0 0 2-2z"></path>
-            </svg>
+            <img src="assets/icons/communication.svg" alt="Icon Kommunikation &amp; Kollaboration" data-alt-en="Icon Communication &amp; Collaboration" width="28" height="28" decoding="async" loading="lazy" />
           </div>
           <div class="counter-number" data-target="3.1" data-unit="%" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:baseline;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
             <span class="prefix" style="font-size:1.8rem;line-height:1;"></span>


### PR DESCRIPTION
## Summary
- Use shared system-quality icon file for pitch and analysis dimensions
- Display communication & collaboration icon in pitch section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af4fef5a848326ba11b34d3c0ab706