### PR TITLE
Swap workload icon usage for process and workload sections

### DIFF
--- a/assets/icons/workload-alt.svg
+++ b/assets/icons/workload-alt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#0052a5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="23 18 13.5 8.5 8.5 13.5 1 6"/>
+  <polyline points="17 18 23 18 23 12"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -509,9 +509,7 @@
         <!-- Card 6: Arbeitsbelastung (–8,5 %) -->
         <div class="counter-card" style="position:relative;background:linear-gradient(to bottom right,rgba(255,255,255,0.9),rgba(245,250,255,0.9));backdrop-filter:blur(12px);padding:1.75rem;border-radius:1rem;box-shadow:0 10px 24px rgba(0,0,0,0.07);text-align:center;">
           <div class="icon-wrapper" style="width:48px;height:48px;margin:0 auto 0.75rem auto;display:flex;align-items:center;justify-content:center;background:rgba(37,88,235,0.12);border-radius:50%;">
-            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" color="var(--accent)">
-              <polyline points="20 6 9 17 4 12"></polyline>
-            </svg>
+            <img src="assets/icons/workload-alt.svg" alt="Icon Arbeitsbelastung" data-alt-en="Icon Workload" width="28" height="28" decoding="async" loading="lazy" />
           </div>
           <div class="counter-number" data-target="-8.5" data-unit="%" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:baseline;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
             <span class="prefix" style="font-size:1.8rem;line-height:1;"></span>
@@ -644,7 +642,7 @@
     <div class="dim-grid">
          <article class="dim-card">
           <div class="dim-icon-ring">
-            <img src="assets/icons/process.svg" alt="Icon Arbeitsprozesse" data-alt-en="Icon Work processes" width="22" height="22" decoding="async" loading="lazy" />
+            <img src="assets/icons/workload.svg" alt="Icon Arbeitsprozesse" data-alt-en="Icon Work processes" width="22" height="22" decoding="async" loading="lazy" />
           </div>
           <h3>
             <span class="lang lang-de">Arbeitsprozesse</span>
@@ -714,7 +712,7 @@
       
       <article class="dim-card">
         <div class="dim-icon-ring">
-          <img src="assets/icons/workload.svg" alt="Icon Arbeitsbelastung" data-alt-en="Icon Workload" width="22" height="22" decoding="async" loading="lazy" />
+          <img src="assets/icons/workload-alt.svg" alt="Icon Arbeitsbelastung" data-alt-en="Icon Workload" width="22" height="22" decoding="async" loading="lazy" />
         </div>
         <h3>
           <span class="lang lang-de">Arbeitsbelastung</span>


### PR DESCRIPTION
## Summary
- Use existing workload icon for the Arbeitsprozesse dimension
- Add new trend-down icon for Arbeitsbelastung and reuse it in pitch counters

## Testing
- `npm test` *(fails: package.json not found)*
- `npx --yes prettier@3.2.5 index.html --check` *(warn: code style issues)*
- `npx --yes prettier@3.2.5 assets/icons/workload-alt.svg --check --parser html` *(warn: code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68af53d06a608326bd140cbe4a9685a0