### PR TITLE
feat: add dual-gear workload icon

### DIFF
--- a/assets/icons/workload-alt.svg
+++ b/assets/icons/workload-alt.svg
@@ -1,17 +1,22 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#0052a5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <circle cx="8" cy="7" r="2" />
-  <path d="M8 9v5" />
-  <path d="M6 14v7" />
-  <path d="M10 14v7" />
-  <path d="M5 11h6" />
-  <circle cx="17" cy="8" r="2" />
-  <circle cx="17" cy="8" r="1" />
-  <path d="M17 6v-1" />
-  <path d="M17 10v1" />
-  <path d="M15 8h-1" />
-  <path d="M19 8h1" />
-  <path d="M15.7 6.3l-.7-.7" />
-  <path d="M18.3 6.3l.7-.7" />
-  <path d="M15.7 9.7l-.7.7" />
-  <path d="M18.3 9.7l.7.7" />
+  <circle cx="9" cy="15" r="3" />
+  <circle cx="9" cy="15" r="2" />
+  <path d="M9 12v-1" />
+  <path d="M9 18v1" />
+  <path d="M6 15h-1" />
+  <path d="M12 15h1" />
+  <path d="M6.9 12.9l-.7-.7" />
+  <path d="M11.1 12.9l.7-.7" />
+  <path d="M6.9 17.1l-.7.7" />
+  <path d="M11.1 17.1l.7.7" />
+  <circle cx="12" cy="11" r="2" />
+  <circle cx="12" cy="11" r="1" />
+  <path d="M12 9v-1" />
+  <path d="M12 13v1" />
+  <path d="M10 11h-1" />
+  <path d="M14 11h1" />
+  <path d="M10.6 9.6l-.7-.7" />
+  <path d="M13.4 9.6l.7-.7" />
+  <path d="M10.6 12.4l-.7.7" />
+  <path d="M13.4 12.4l.7.7" />
 </svg>


### PR DESCRIPTION
## Summary
- replace workload icon with dual-gear design for workload representation

## Testing
- `npm test` *(fails: could not read package.json)*
- `npx --yes htmlhint index.html assets/icons/workload-alt.svg`


------
https://chatgpt.com/codex/tasks/task_e_68af5e0e17a08326b19284f08d161597