### PR TITLE
feat: add minimalist workload icon

### DIFF
--- a/assets/icons/workload.svg
+++ b/assets/icons/workload.svg
@@ -1,4 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#0052a5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <circle cx="12" cy="12" r="10"/>
-  <polyline points="12 6 12 12 16 14"/>
+  <path d="M4 17h16" />
+  <path d="M8 17V13" />
+  <path d="M12 17V9" />
+  <path d="M16 17V5" />
 </svg>


### PR DESCRIPTION
## Summary
- refine workload icon with ascending bar chart style to align with other icons

## Testing
- `npx --yes htmlhint "./*.html"`


------
https://chatgpt.com/codex/tasks/task_e_68af61493628832689f4b455c81be915