### PR TITLE
Use clock icon for work processes dimension

### DIFF
--- a/assets/icons/workload.svg
+++ b/assets/icons/workload.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#0052a5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <polyline points="12 6 12 12 16 14"/>
+</svg>


### PR DESCRIPTION
## Summary
- add clock SVG icon from pitch section for reuse as "Arbeitsprozesse" icon within the analysis dimensions.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af69c3f944832697ca1167ccb7d6cf