### PR TITLE
Align pitch prefix icons with numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,7 +425,7 @@
               <polyline points="12 6 12 12 16 14"></polyline>
             </svg>
           </div>
-            <div class="counter-number" data-target="-29" data-unit="min" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:baseline;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
+            <div class="counter-number" data-target="-29" data-unit="min" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:center;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
               <span class="prefix" style="font-size:1.8rem;line-height:1;">-</span>
               <span class="number">0</span>
               <span class="unit" style="font-size:1.4rem;">min</span>
@@ -441,7 +441,7 @@
           <div class="icon-wrapper" style="width:48px;height:48px;margin:0 auto 0.75rem auto;display:flex;align-items:center;justify-content:center;background:rgba(37,88,235,0.12);border-radius:50%;">
             <img src="assets/icons/system-quality.svg" alt="Icon Systemqualität" data-alt-en="Icon System quality" width="28" height="28" decoding="async" loading="lazy" />
           </div>
-          <div class="counter-number" data-target="49" data-unit="%" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:baseline;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
+          <div class="counter-number" data-target="49" data-unit="%" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:center;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
             <span class="prefix" style="font-size:1.8rem;line-height:1;"></span>
             <span class="number">0</span>
             <span class="unit" style="font-size:1.4rem;">%</span>
@@ -461,7 +461,7 @@
               <line x1="12" y1="8" x2="12" y2="8"></line>
             </svg>
           </div>
-          <div class="counter-number" data-target="19" data-unit="%" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:baseline;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
+          <div class="counter-number" data-target="19" data-unit="%" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:center;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
             <span class="prefix" style="font-size:1.8rem;line-height:1;"></span>
             <span class="number">0</span>
             <span class="unit" style="font-size:1.4rem;">%</span>
@@ -477,7 +477,7 @@
           <div class="icon-wrapper" style="width:48px;height:48px;margin:0 auto 0.75rem auto;display:flex;align-items:center;justify-content:center;background:rgba(37,88,235,0.12);border-radius:50%;">
             <img src="assets/icons/communication.svg" alt="Icon Kommunikation &amp; Kollaboration" data-alt-en="Icon Communication &amp; Collaboration" width="28" height="28" decoding="async" loading="lazy" />
           </div>
-          <div class="counter-number" data-target="3.1" data-unit="%" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:baseline;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
+          <div class="counter-number" data-target="3.1" data-unit="%" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:center;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
             <span class="prefix" style="font-size:1.8rem;line-height:1;"></span>
             <span class="number">0</span>
             <span class="unit" style="font-size:1.4rem;">%</span>
@@ -498,7 +498,7 @@
               <line x1="15" y1="9" x2="15" y2="9"></line>
             </svg>
           </div>
-          <div class="counter-number" data-target="20" data-unit="%" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:baseline;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
+          <div class="counter-number" data-target="20" data-unit="%" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:center;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
             <span class="prefix" style="font-size:1.8rem;line-height:1;"></span>
             <span class="number">0</span>
             <span class="unit" style="font-size:1.4rem;">%</span>
@@ -514,7 +514,7 @@
           <div class="icon-wrapper" style="width:48px;height:48px;margin:0 auto 0.75rem auto;display:flex;align-items:center;justify-content:center;background:rgba(37,88,235,0.12);border-radius:50%;">
             <img src="assets/icons/workload-alt.svg" alt="Icon Arbeitsbelastung" data-alt-en="Icon Workload" width="28" height="28" decoding="async" loading="lazy" />
           </div>
-          <div class="counter-number" data-target="-8.5" data-unit="%" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:baseline;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
+          <div class="counter-number" data-target="-8.5" data-unit="%" style="font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:center;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;">
             <span class="prefix" style="font-size:1.8rem;line-height:1;"></span>
             <span class="number">0</span>
             <span class="unit" style="font-size:1.4rem;">%</span>


### PR DESCRIPTION
## Summary
- center plus/minus prefixes in pitch counters to align with numbers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af6b4d51dc8326b1058048fff26d8f