### PR TITLE
Fix mobile flip-card layout for analysis dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -651,6 +651,23 @@
     grid-template-columns: repeat(3, 1fr);
     gap: clamp(1rem, 2vw, 1.5rem);
   }
+
+  /* Responsive grid layout */
+  @media (max-width: 1024px) {
+    #dimensionen .dim-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (max-width: 640px) {
+    #dimensionen .dim-grid {
+      grid-template-columns: 1fr;
+    }
+
+    #dimensionen .dim-more-btn {
+      width: 100%;
+    }
+  }
   /* Flip‑Card Container */
   #dimensionen .flip-card {
     position: relative;


### PR DESCRIPTION
## Summary
- Make analysis dimension flip-cards responsive with breakpoints for tablets and phones.
- Ensure card buttons size correctly on narrow screens.

## Testing
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b04db523f08326b30d6dd6318b5724