### PR TITLE
Align About section styling with site design

### DIFF
--- a/index.html
+++ b/index.html
@@ -567,10 +567,19 @@
 <!-- Eigene CSS-Definitionen, damit keine Build-Anpassung nötig ist -->
 <style>
   .about-me-section {
-    padding: 4rem 1rem;
-    background: linear-gradient(180deg, var(--accent-light) 0%, var(--background) 100%);
-    border-top: 1px solid var(--light-gray);
-    border-bottom: 1px solid var(--light-gray);
+    max-width: 1200px;
+    margin: 0 auto 1.25rem;
+    padding: 3rem 1.5rem;
+    background:
+      radial-gradient(
+        circle at 20% 20%,
+        rgba(37,99,235,0.08),
+        transparent 70%
+      ),
+      #fff;
+    border: 1px solid rgba(23,37,84,0.1);
+    border-radius: 20px;
+    box-shadow: 0 8px 40px rgba(23,37,84,0.08);
     position: relative;
     overflow: hidden;
   }
@@ -582,8 +591,8 @@
     background: radial-gradient(80% 140% at 50% 0%, rgba(37,99,235,0.03), transparent 70%);
   }
   .about-wrap {
-    max-width: 960px;
-    margin: 0 auto;
+    max-width: 100%;
+    margin: 0;
     display: grid;
     grid-template-columns: 200px 1fr;
     gap: 2rem;
@@ -641,6 +650,9 @@
     font-style: normal;
   }
   @media (max-width: 700px) {
+    .about-me-section {
+      padding: 2rem 1rem;
+    }
     .about-wrap {
       grid-template-columns: 1fr;
       text-align: center;
@@ -653,6 +665,12 @@
     .about-content blockquote::before {
       left: 50%;
       transform: translateX(-50%);
+    }
+  }
+  @media (min-width: 1024px) {
+    .about-me-section {
+      padding: 4rem 2rem;
+      margin-bottom: 1.5rem;
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- Match About-me section width and styling to other sections with a framed container, border and shadow
- Improve mobile layout with responsive padding and single-column stacking

## Testing
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68b063589eec832683ffdfbaed00ed44