### PR TITLE
Add English translation for About Me section

### DIFF
--- a/index.html
+++ b/index.html
@@ -626,34 +626,26 @@
    <section class="section about-me-section" id="about-me">
     <div class="about-wrap">
      <div class="about-img">
-      <img alt="Dr. Florian Eisold" src="assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg"/>
+      <img alt="Dr. Florian Eisold" decoding="async" loading="lazy" src="assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg" width="160" height="160"/>
      </div>
      <div class="about-content">
       <blockquote>
        <p>
-        Ich habe IMHIS entwickelt, weil ich an eine Medizin glaube, in der Technologie wieder dem Menschen dient.
+        <span class="lang lang-de">Ich habe IMHIS entwickelt, weil ich an eine Medizin glaube, in der Technologie wieder dem Menschen dient.</span>
+        <span class="lang lang-en" hidden="">I developed IMHIS because I believe in medicine where technology once again serves people.</span>
        </p>
        <p>
-        Nicht das System braucht unsere Zeit –
-        <span class="highlight">
-         die Patienten tun es
-        </span>
-        .
+        <span class="lang lang-de">Nicht das System braucht unsere Zeit – <span class="highlight">die Patienten tun es</span>.</span>
+        <span class="lang lang-en" hidden="">It's not the system that needs our time – <span class="highlight">the patients do</span>.</span>
        </p>
        <p>
-        Was wir brauchen, ist eine Digitalisierung, die
-        <span class="highlight">
-         spürbar entlastet
-        </span>
-        und
-        <span class="highlight">
-         messbar wirkt
-        </span>
-        .
+        <span class="lang lang-de">Was wir brauchen, ist eine Digitalisierung, die <span class="highlight">spürbar entlastet</span> und <span class="highlight">messbar wirkt</span>.</span>
+        <span class="lang lang-en" hidden="">What we need is digitalisation that <span class="highlight">provides tangible relief</span> and <span class="highlight">has measurable impact</span>.</span>
        </p>
       </blockquote>
       <cite>
-       Dr. med. Florian Eisold, B.Sc., LL.M. – Arzt und Entwickler von IMHIS
+       <span class="lang lang-de">Dr. med. Florian Eisold, B.Sc., LL.M. – Arzt und Entwickler von IMHIS</span>
+       <span class="lang lang-en" hidden="">Dr. Florian Eisold, M.D., B.Sc., LL.M. – physician and developer of IMHIS</span>
       </cite>
       <a class="btn-primary about-cta" href="mailto:florianeisold@outlook.de">
        <span class="lang lang-de">


### PR DESCRIPTION
## Summary
- Add English translations to About Me blockquote and attribution
- Optimize about image with lazy loading and defined dimensions

## Testing
- `npx htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b06a867fa88326b0ca5e5cc5b6d945