### PR TITLE
Align About Me width with other sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -683,7 +683,7 @@
 <style>
   .about-me-section{
     --accent:#2563eb; --ink:#0b1220;
-    max-width:1150px; margin:3rem auto; padding:4rem 2.5rem;
+    max-width:960px; margin:3rem auto; padding:4rem 1rem;
     border-radius:28px; position:relative; overflow:hidden;
     background:linear-gradient(180deg,#fff,rgba(248,250,252,.9));
     border:1px solid rgba(23,37,84,.06);
@@ -728,13 +728,17 @@
     box-shadow:0 10px 28px rgba(37,99,235,.25); transition:all .25s ease;
   }
   .about-cta:hover{ transform:translateY(-2px); box-shadow:0 14px 32px rgba(37,99,235,.35); }
-  .about-cta .cta-icon{ width:16px; height:16px; stroke:currentColor; transition:transform .25s ease; }
+  .about-cta .cta-icon{ width:16px; height:16px; stroke:currentColor; transition:transform .25s ease; display:block; }
   .about-cta:hover .cta-icon{ transform:translateX(4px); }
 
   @media (max-width:860px){
     .about-wrap{ grid-template-columns:1fr; text-align:center; }
     .about-img img{ margin:0 auto 1.5rem; }
     .about-quote::before{ left:50%; transform:translateX(-50%); top:-2rem; }
+  }
+
+  @media (max-width:640px){
+    .about-me-section{ padding:3rem 1rem; }
   }
 </style>
    <!-- Instrument – aligned to Book & Dimensionen -->


### PR DESCRIPTION
## Summary
- Match About Me section max-width and padding with other sections
- Center contact button arrow relative to text
- Improve mobile spacing for About Me layout

## Testing
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68b06f81b06483269987271a1998eba8