### PR TITLE
Refine About Me section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -653,9 +653,6 @@
       <a class="btn-primary about-cta" href="mailto:florianeisold@outlook.de">
         <span class="lang lang-de">Kontakt aufnehmen</span>
         <span class="lang lang-en" hidden>Get in touch</span>
-        <svg class="cta-icon" fill="none" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M12 5l7 7-7 7"/>
-        </svg>
       </a>
     </div>
   </div>
@@ -665,7 +662,7 @@
 <style>
   .about-me-section{
     --accent:#2563eb; --ink:#0b1220;
-    max-width:960px; margin:3rem auto; padding:4rem 1rem;
+    max-width:1200px; margin:3rem auto; padding:4rem 1rem;
     border-radius:28px; position:relative; overflow:hidden;
     background:linear-gradient(180deg,#fff,rgba(248,250,252,.9));
     border:1px solid rgba(23,37,84,.06);
@@ -678,6 +675,7 @@
     z-index:0;
   }
   .about-wrap{position:relative; z-index:1; display:grid; grid-template-columns:200px 1fr; gap:3rem; align-items:center;}
+  .about-img{margin-left:2rem;}
   .about-img img{
     width:200px; height:200px; border-radius:50%; object-fit:cover;
     box-shadow:0 8px 24px rgba(0,0,0,.08); border:6px solid #fff;
@@ -710,11 +708,10 @@
     box-shadow:0 10px 28px rgba(37,99,235,.25); transition:all .25s ease;
   }
   .about-cta:hover{ transform:translateY(-2px); box-shadow:0 14px 32px rgba(37,99,235,.35); }
-  .about-cta .cta-icon{ width:16px; height:16px; stroke:currentColor; transition:transform .25s ease; display:block; }
-  .about-cta:hover .cta-icon{ transform:translateX(4px); }
 
   @media (max-width:860px){
     .about-wrap{ grid-template-columns:1fr; text-align:center; }
+    .about-img{ margin-left:0; }
     .about-img img{ margin:0 auto 1.5rem; }
     .about-quote::before{ left:50%; transform:translateX(-50%); top:-2rem; }
   }


### PR DESCRIPTION
## Summary
- Make About Me section match page width
- Remove arrow icon from "Kontakt aufnehmen" button
- Balance spacing around profile photo with responsive adjustments

## Testing
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b08ebff3b483269f11d91a71fed463