### PR TITLE
Equalize About me image spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -675,7 +675,7 @@
     z-index:0;
   }
   .about-wrap{position:relative; z-index:1; display:grid; grid-template-columns:200px 1fr; gap:3rem; align-items:center;}
-  .about-img{margin-left:2rem;}
+  .about-img{margin-left:3rem;}
   .about-img img{
     width:200px; height:200px; border-radius:50%; object-fit:cover;
     box-shadow:0 8px 24px rgba(0,0,0,.08); border:6px solid #fff;


### PR DESCRIPTION
## Summary
- Adjust About me section image spacing so left margin matches right gap for balanced layout

## Testing
- `npx htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b0939557b4832680da5f9d5b8865fc