### PR TITLE
Scope instrument styles to fix pitch layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -812,9 +812,9 @@
     </div>
 </section>
 
-<!-- Lokale Styles nur für diese Section -->
+<!-- Lokale Styles nur für die Instrument-Section -->
 <style>
-  .section.instrument-pro{
+  #instrument{
     --accent:#2563eb; --ink:#0f172a; --brand:#172554;
     max-width:1200px; margin:3.25rem auto;
     position:relative; border-radius:28px; overflow:hidden;
@@ -823,24 +823,24 @@
     box-shadow:0 12px 36px rgba(15,23,42,.06);
     padding:60px 1.5rem;
   }
-  .orb{
+  #instrument .orb{
     position:absolute; right:-15%; top:-25%; width:700px; height:700px;
     background:radial-gradient(circle at 70% 30%, rgba(37,99,235,.08), transparent 70%);
     filter:blur(60px);
   }
-  .soft{
+  #instrument .soft{
     position:absolute; left:-20%; bottom:-25%; width:540px; height:540px;
     background:radial-gradient(circle at 50% 50%, rgba(23,37,84,.06), transparent 60%);
     filter:blur(55px);
   }
 
-  .section.instrument-pro .inner{
+  #instrument .inner{
     position:relative; z-index:1;
     max-width:100%; margin:0;
     text-align:left;
   }
 
-  .eyebrow{
+  #instrument .eyebrow{
     display:inline-block; padding:.38rem .8rem; border-radius:999px;
     font-weight:600; font-size:.8rem; letter-spacing:.05em; text-transform:uppercase;
     color:var(--accent); background:rgba(37,99,235,.08); border:1px solid rgba(37,99,235,.15);
@@ -850,40 +850,40 @@
     margin:0 0 1rem; font-weight:800; color:var(--brand);
     font-size:clamp(1.6rem,2.4vw,2rem); line-height:1.3;
   }
-  .lead{
+  #instrument .lead{
     margin:0 0 1rem; color:#334155; font-size:1rem; line-height:1.55;
   }
-  .lead strong{ color:var(--ink); }
-  .body{
+  #instrument .lead strong{ color:var(--ink); }
+  #instrument .body{
     margin:0 0 1.5rem; color:#475569; font-size:1rem; line-height:1.55;
   }
-  .accent{
+  #instrument .accent{
     color:var(--accent); font-weight:650; position:relative;
   }
-  .accent::after{
+  #instrument .accent::after{
     content:""; position:absolute; left:0; right:0; bottom:-2px;
     height:4px; border-radius:4px;
     background:linear-gradient(90deg, rgba(37,99,235,.14), rgba(37,99,235,.06));
   }
 
   /* Benefits – linksbündig, kompakt, mit Haken */
-  .benefits{ display:grid; gap:16px; margin-top:28px; }
-  .benefit{ display:flex; align-items:flex-start; gap:12px; }
-  .check{
+  #instrument .benefits{ display:grid; gap:16px; margin-top:28px; }
+  #instrument .benefit{ display:flex; align-items:flex-start; gap:12px; }
+  #instrument .check{
     flex:0 0 24px; height:24px; border-radius:50%;
     background:var(--accent); display:grid; place-items:center;
     box-shadow:0 2px 6px rgba(37,99,235,.25);
   }
-  .check svg{ width:14px; height:14px; color:#fff; }
-  .benefit-content h3{
+  #instrument .check svg{ width:14px; height:14px; color:#fff; }
+  #instrument .benefit-content h3{
     margin:0; font-size:.95rem; font-weight:600; color:var(--ink);
   }
-  .benefit-content p{
+  #instrument .benefit-content p{
     margin:2px 0 0; color:#475569; font-size:.9rem; line-height:1.4;
   }
 
   @media (max-width:700px){
-    .section.instrument-pro{ padding:40px 1rem; }
+    #instrument{ padding:40px 1rem; }
   }
 </style>
    <section aria-labelledby="dim-title" class="section dimensionen-section dim-matched dim-peopleix" id="dimensionen">


### PR DESCRIPTION
## Summary
- Scope instrument section CSS to `#instrument` so pitch section no longer inherits extra frame styles

## Testing
- `npx htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b0a635efd08326bb176e08e944072b