### PR TITLE
Hide English translations in pitch section

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,7 +354,7 @@
        <span class="lang lang-de">
         Jetzt alle Effekte mit IMHIS sichtbar machen
        </span>
-       <span class="lang lang-en">
+       <span class="lang lang-en" hidden>
         Reveal all effects with IMHIS now
        </span>
       </a>
@@ -390,7 +390,7 @@
           </strong>
           pro Schicht*
          </span>
-         <span class="lang lang-en">
+         <span class="lang lang-en" hidden>
           less
           <strong>
            documentation
@@ -422,7 +422,7 @@
           </strong>
           *
          </span>
-         <span class="lang lang-en">
+         <span class="lang lang-en" hidden>
           higher
           <strong>
            system quality
@@ -461,7 +461,7 @@
           </strong>
           *
          </span>
-         <span class="lang lang-en">
+         <span class="lang lang-en" hidden>
           better
           <strong>
            information quality
@@ -493,7 +493,7 @@
           </strong>
           *
          </span>
-         <span class="lang lang-en">
+         <span class="lang lang-en" hidden>
           better
           <strong>
            communication &amp; collaboration*
@@ -534,7 +534,7 @@
           </strong>
           *
          </span>
-         <span class="lang lang-en">
+         <span class="lang lang-en" hidden>
           higher
           <strong>
            user satisfaction
@@ -566,7 +566,7 @@
           </strong>
           *
          </span>
-         <span class="lang lang-en">
+         <span class="lang lang-en" hidden>
           lower
           <strong>
            workload


### PR DESCRIPTION
## Summary
- ensure only one language is visible in pitch section by hiding English translations by default

## Testing
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b151b6e1e883269ba1fd856caa0b56