### PR TITLE
Align pitch section styling with about-me section

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@
         Mit IMHIS die
        <span class="black-box">Black Box</span>
         des
-        <span class="accent-text">
+        <span class="accent">
          Klinikalltages
         </span>
         öffnen – Schwächen erkennen, Stärken ausbauen, Wirkung sichern.
@@ -319,6 +319,16 @@
       </span>
      </p>
      <style>
+        #pitch .instrument-outer{
+    max-width:1200px;
+    margin:0 auto 1.25rem;
+    background:linear-gradient(180deg,#fff,rgba(248,250,252,.9));
+    border:1px solid rgba(23,37,84,.06);
+    border-radius:28px;
+    box-shadow:0 12px 40px rgba(15,23,42,.06);
+    padding:4rem 1.5rem;
+    font-family:"Inter",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+  }
         .black-box{
     display:inline-block;
     padding:.08rem .42rem;
@@ -328,9 +338,35 @@
     background:linear-gradient(180deg,#0b111f,#0a1326);
     border:1px solid rgba(255,255,255,.08);
     box-shadow:inset 0 1px 0 rgba(255,255,255,.06), 0 6px 14px rgba(2,6,23,.18);
+    transition:all .3s ease;
+  }
+  .black-box:hover{
+    background:transparent;
+    color:inherit;
+    border-color:transparent;
+    box-shadow:none;
+  }
+  #pitch .accent{
+    color:var(--accent);
+    font-weight:650;
+    position:relative;
+  }
+  #pitch .accent::after{
+    content:"";
+    position:absolute;
+    left:0;right:0;bottom:-2px;
+    height:4px;
+    border-radius:4px;
+    background:linear-gradient(90deg,rgba(37,99,235,.14),rgba(37,99,235,.06));
+  }
+  #pitch .lead{
+    font-weight:400;
+    font-size:clamp(1.3rem,2.3vw,1.65rem);
+    line-height:1.55;
+    color:#1e293b;
   }
       .analysis-header{display:flex;align-items:center;gap:1rem;margin-top:2rem;margin-bottom:1rem;flex-wrap:wrap;}
-      @media (max-width:700px){.analysis-header{flex-direction:column;align-items:flex-start;}.analysis-header .btn-primary{margin-top:1rem;}}
+      @media (max-width:700px){.analysis-header{flex-direction:column;align-items:flex-start;}.analysis-header .pitch-cta{margin-top:1rem;}}
      </style>
      <div class="analysis-header">
       <!-- Analysebeispiel: digitale Patientenkurve (Badge) -->
@@ -358,7 +394,7 @@
         </strong>
        </span>
       </div>
-      <a class="btn-primary" href="#pitch" id="reveal-effects">
+      <a class="about-cta pitch-cta" href="#pitch" id="reveal-effects">
        <span class="lang lang-de">
         Jetzt alle Effekte mit IMHIS sichtbar machen
        </span>


### PR DESCRIPTION
## Summary
- Style pitch section container and typography to match about-me design.
- Highlight "Klinikalltages" with same accent underline as analysis instrument section.
- Add hover effect removing the "Black Box" styling and restyle pitch button like contact CTA.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1603839ec83269f7e4ce47c07a70a