### PR TITLE
Adjust pitch badge color and sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,7 +347,7 @@
     box-shadow:none;
   }
   #pitch .accent{
-    color:var(--accent);
+    color:var(--link);
     font-weight:650;
     position:relative;
   }
@@ -370,8 +370,8 @@
      </style>
      <div class="analysis-header">
       <!-- Analysebeispiel: digitale Patientenkurve (Badge) -->
-      <div class="analysis-badge" style="display:inline-flex;align-items:center;gap:0.5rem;background:rgba(37,88,235,0.05);border:0;border-radius:0.5rem;padding:0.5rem 0.9rem;font-size:1rem;font-weight:600;color:var(--accent);">
-       <svg color="var(--accent)" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.7" viewbox="0 0 24 24" width="24">
+      <div class="analysis-badge" style="display:inline-flex;align-items:center;gap:0.6rem;background:rgba(37,99,235,0.1);border:0;border-radius:14px;padding:1rem 1.5rem;font-size:1rem;font-weight:600;color:var(--link);">
+       <svg color="var(--link)" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.7" viewbox="0 0 24 24" width="24">
         <rect height="8" rx="0.6" width="3" x="3" y="13">
         </rect>
         <rect height="12" rx="0.6" width="3" x="8" y="9">


### PR DESCRIPTION
## Summary
- Match 'Klinikalltages' text color with analysis section accent
- Restyle analysis badge with lighter blue and enlarged padding to mirror CTA button

## Testing
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68b1622c0f088326a39e3b6fc46bd02e