### PR TITLE
style: modernize hero benefits

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,9 +235,8 @@
    </section>
    <section aria-label="Vorteile" class="benefits-block">
     <div class="benefit-item">
-     <svg aria-hidden="true" fill="none" height="20" viewbox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-      <path d="M5 13l4 4L19 7" stroke="#2563eb" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5">
-      </path>
+     <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+      <path d="M5 13l4 4L19 7" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5"></path>
      </svg>
      <span>
       <span class="lang lang-de">
@@ -249,9 +248,8 @@
      </span>
     </div>
     <div class="benefit-item">
-     <svg aria-hidden="true" fill="none" height="20" viewbox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-      <path d="M5 13l4 4L19 7" stroke="#2563eb" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5">
-      </path>
+     <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+      <path d="M5 13l4 4L19 7" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5"></path>
      </svg>
      <span>
       <span class="lang lang-de">
@@ -263,9 +261,8 @@
      </span>
     </div>
     <div class="benefit-item">
-     <svg aria-hidden="true" fill="none" height="20" viewbox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-      <path d="M5 13l4 4L19 7" stroke="#2563eb" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5">
-      </path>
+     <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+      <path d="M5 13l4 4L19 7" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5"></path>
      </svg>
      <span>
       <span class="lang lang-de">

--- a/styles/main.css
+++ b/styles/main.css
@@ -639,12 +639,18 @@ footer a {
 .benefits-block {
     max-width: 1200px;
     margin: 1rem auto 2rem;
-    padding: 0 1.5rem;
+    padding: 1.25rem 1.5rem;
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 1rem;
     flex-direction: column;
+    gap: 1rem;
+    background:
+        radial-gradient(circle at 20% 20%, rgba(37, 99, 235, 0.06), transparent 70%),
+        #fff;
+    border: 1px solid rgba(23, 37, 84, 0.1);
+    border-radius: 20px;
+    box-shadow: 0 8px 40px rgba(23, 37, 84, 0.08);
 }
 
 .benefits-actions {
@@ -663,54 +669,27 @@ footer a {
 }
 
 .benefits-block .benefit-item {
-    position: relative;
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.75rem 1.25rem;
     font-family: "Inter", sans-serif;
     font-weight: 600;
     letter-spacing: 0.02em;
     color: #172554;
-    background: linear-gradient(135deg,
-            rgba(37, 99, 235, 0.05),
-            rgba(23, 37, 84, 0.05));
-    border: 1px solid rgba(23, 37, 84, 0.15);
-    border-radius: 14px;
-    box-shadow: 0 2px 4px rgba(23, 37, 84, 0.08);
-    transition:
-        transform 0.2s ease,
-        box-shadow 0.2s ease;
-}
-
-.benefits-block .benefit-item:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 4px 8px rgba(23, 37, 84, 0.15);
 }
 
 .benefits-block .benefit-item svg {
+    width: 20px;
+    height: 20px;
+    color: #2563eb;
     flex-shrink: 0;
-}
-
-.benefits-block .benefit-item:not(:last-child)::after {
-    content: none;
 }
 
 @media (min-width: 641px) {
     .benefits-block {
         flex-direction: row;
+        flex-wrap: wrap;
         gap: 2rem;
-    }
-
-    .benefits-block .benefit-item:not(:last-child)::after {
-        content: "";
-        position: absolute;
-        top: 50%;
-        right: -1rem;
-        transform: translateY(-50%);
-        width: 1px;
-        height: 60%;
-        background: rgba(23, 37, 84, 0.15);
     }
 }
 


### PR DESCRIPTION
## Summary
- restyle hero benefits container with subtle gradient, rounded borders, and soft shadow to match pitch block aesthetics
- unify check icons to use CSS-driven color

## Testing
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b173c87fc48326b4cd2981076e1d8b