### PR TITLE
Align analysis instrument section with lead typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -734,12 +734,12 @@
 
       <p class="lead">
         <span class="lang lang-de">
-          <strong>IMHIS</strong> verbindet wissenschaftliche Präzision mit Praxisnähe: Es macht sichtbar, wie digitale Systeme das Gesundheitswesen wirklich beeinflussen – aus der Perspektive der Menschen, die täglich damit arbeiten:
-          <strong>dem medizinischen Personal</strong>.
+          <span class="emph">IMHIS</span> verbindet wissenschaftliche Präzision mit Praxisnähe: Es macht sichtbar, wie digitale Systeme das Gesundheitswesen wirklich beeinflussen – aus der Perspektive der Menschen, die täglich damit arbeiten:
+          <span class="emph">dem medizinischen Personal</span>.
         </span>
         <span class="lang lang-en" hidden>
-          <strong>IMHIS</strong> combines scientific precision with practical relevance: it reveals how digital systems truly impact healthcare—from the perspective of the people who work with them every day:
-          <strong>the medical staff</strong>.
+          <span class="emph">IMHIS</span> combines scientific precision with practical relevance: it reveals how digital systems truly impact healthcare—from the perspective of the people who work with them every day:
+          <span class="emph">the medical staff</span>.
         </span>
       </p>
 
@@ -839,10 +839,6 @@
     margin:0 0 1rem; font-weight:800; color:var(--brand);
     font-size:clamp(1.6rem,2.4vw,2rem); line-height:1.3;
   }
-  #instrument .lead{
-    margin:0 0 1rem; color:#334155; font-size:1rem; line-height:1.55;
-  }
-  #instrument .lead strong{ color:var(--ink); }
   #instrument .body{
     margin:0 0 1.5rem; color:#475569; font-size:1rem; line-height:1.55;
   }


### PR DESCRIPTION
### Summary
- Apply shared lead typography to the analysis instrument section by using `.emph` spans and relying on global styles.
- Remove section-specific lead overrides to match the design of other sections.

### Testing
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b179ab4cfc8326b00a2b860660345d