### PR TITLE
Enhance hero visuals and logo tagline

### DIFF
--- a/assets/analysis-bg.svg
+++ b/assets/analysis-bg.svg
@@ -1,12 +1,12 @@
 <svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
-  <g stroke="#0052a5" stroke-opacity="0.5" stroke-width="2" fill="none">
-    <circle cx="200" cy="200" r="6" fill="#0052a5" fill-opacity="0.5" />
-    <circle cx="600" cy="150" r="6" fill="#0052a5" fill-opacity="0.5" />
-    <circle cx="1000" cy="300" r="6" fill="#0052a5" fill-opacity="0.5" />
-    <circle cx="1400" cy="250" r="6" fill="#0052a5" fill-opacity="0.5" />
-    <circle cx="400" cy="500" r="6" fill="#0052a5" fill-opacity="0.5" />
-    <circle cx="800" cy="550" r="6" fill="#0052a5" fill-opacity="0.5" />
-    <circle cx="1200" cy="600" r="6" fill="#0052a5" fill-opacity="0.5" />
+  <g stroke="#0052a5" stroke-opacity="0.7" stroke-width="2" fill="none">
+    <circle cx="200" cy="200" r="6" fill="#0052a5" fill-opacity="0.7" />
+    <circle cx="600" cy="150" r="6" fill="#0052a5" fill-opacity="0.7" />
+    <circle cx="1000" cy="300" r="6" fill="#0052a5" fill-opacity="0.7" />
+    <circle cx="1400" cy="250" r="6" fill="#0052a5" fill-opacity="0.7" />
+    <circle cx="400" cy="500" r="6" fill="#0052a5" fill-opacity="0.7" />
+    <circle cx="800" cy="550" r="6" fill="#0052a5" fill-opacity="0.7" />
+    <circle cx="1200" cy="600" r="6" fill="#0052a5" fill-opacity="0.7" />
     <line x1="200" y1="200" x2="600" y2="150" />
     <line x1="600" y1="150" x2="1000" y2="300" />
     <line x1="1000" y1="300" x2="1400" y2="250" />

--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@
         position: absolute;
         inset: 0;
         background: url('assets/analysis-bg.svg') center/cover no-repeat;
-        opacity: 0.1;
+        opacity: 0.25;
         z-index: -1;
       }
 
@@ -294,7 +294,7 @@
       }
 
       .hero-logo svg {
-        width: 400px;
+        width: 480px;
         max-width: 100%;
         height: auto;
         display: block;
@@ -303,8 +303,10 @@
       .hero-tagline {
         margin-top: 1rem;
         font-size: 1.125rem;
-        color: var(--color-primary);
+        color: #203361;
         text-align: center;
+        width: 480px;
+        max-width: 100%;
       }
 
       /* Responsivität */


### PR DESCRIPTION
## Summary
- Increase hero background line visibility by boosting overlay and SVG opacities
- Enlarge animated logo and match tagline width and darker blue text

## Testing
- `npx htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b186bb81208326b4cfee02931f90da