### PR TITLE
Enhance hero logo alignment and highlight digital future

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@
       .hero {
         display: flex;
         flex-wrap: wrap;
-        align-items: center;
+        align-items: flex-start;
         justify-content: space-between;
         max-width: 1200px;
         margin: 0 auto;
@@ -294,10 +294,27 @@
       }
 
       .hero-logo svg {
-        width: 480px;
+        width: 560px;
         max-width: 100%;
         height: auto;
         display: block;
+      }
+
+      .hero .accent {
+        color: var(--link);
+        font-weight: 650;
+        position: relative;
+      }
+
+      .hero .accent::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: -2px;
+        height: 4px;
+        border-radius: 4px;
+        background: linear-gradient(90deg, rgba(37,99,235,.14), rgba(37,99,235,.06));
       }
 
       .hero-tagline {
@@ -486,7 +503,7 @@
    <section class="hero">
        <div class="hero-text">
          <h1>
-           <span class="lang lang-de">Die digitale Zukunft der Versorgung beginnt mit der richtigen Analyse</span>
+           <span class="lang lang-de">Die <span class="accent">digitale Zukunft</span> der Versorgung beginnt mit der richtigen Analyse</span>
            <span class="lang lang-en" hidden>The future of health analysis</span>
          </h1>
          <p>


### PR DESCRIPTION
## Summary
- Align hero section elements and enlarge logo for greater visual weight
- Add reusable accent styling in hero section and apply it to "digitale Zukunft" text

## Testing
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68b194faadc08326b2b456cba379de4c