### PR TITLE
style: align hero logo with headline and reduce title size

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@
       .hero {
         display: flex;
         flex-wrap: wrap;
-        align-items: flex-start;
+        align-items: flex-end;
         justify-content: space-between;
         max-width: 1200px;
         margin: 0 auto;
@@ -266,7 +266,7 @@
       }
 
       .hero-text h1 {
-        font-size: clamp(2rem, 4vw + 1rem, 3.4rem);
+        font-size: clamp(1.8rem, 3.5vw + 0.8rem, 3rem);
         line-height: 1.2;
         margin-bottom: 1.25rem;
         color: var(--color-secondary);


### PR DESCRIPTION
## Summary
- align hero logo with headline's lower line by bottom-aligning hero section content
- slightly reduce hero headline font size for better balance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b19614d9988326a3478570328a7a38