### PR TITLE
Fix hero logo text alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
         flex-direction: column;
         align-items: center;
         justify-content: flex-start;
-        margin-bottom: 2rem;
+        margin: 0 auto 2rem;
         order: -1;
       }
 
@@ -326,7 +326,6 @@
         font-size: 1.5rem;
         color: #203361;
         text-align: center;
-        width: 100%;
       }
 
       .no-wrap {


### PR DESCRIPTION
## Summary
- Center hero logo container and tagline in hero section
- Remove fixed width from hero tagline

## Testing
- `npx -y htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68b1a54ff08c832682b06e9f94c202d1