### PR TITLE
Fix hero overflow and mobile nav links

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,6 +275,7 @@
         line-height: 1.2;
         margin-bottom: 1.25rem;
         color: var(--color-secondary);
+        overflow-wrap: anywhere;
       }
 
       .hero-text p {
@@ -328,6 +329,7 @@
         font-size: 1.5rem;
         color: #203361;
         text-align: center;
+        overflow-wrap: anywhere;
       }
 
       @media (max-width: 600px) {
@@ -350,10 +352,6 @@
           padding: .35rem .75rem;
           font-size: .85rem;
         }
-      }
-
-      .no-wrap {
-        white-space: nowrap;
       }
 
       /* Responsivität */
@@ -569,15 +567,15 @@
      </g>
           </svg>
          <p class="hero-tagline">
-           <span class="lang lang-de no-wrap">Impact Monitor für Gesundheitsinformationssysteme</span>
-           <span class="lang lang-en no-wrap" hidden>Impact Monitor for Health Information Systems</span>
+          <span class="lang lang-de">Impact Monitor für Gesundheitsinformationssysteme</span>
+          <span class="lang lang-en" hidden>Impact Monitor for Health Information Systems</span>
          </p>
         </div>
        <div class="hero-text">
         <h1>
           <span class="lang lang-de">
-            <span class="no-wrap">Die <span class="accent">digitale Zukunft</span> der Gesundheitsversorgung</span><br/>
-            <span class="no-wrap">beginnt mit der richtigen Analyse</span>
+           <span>Die <span class="accent">digitale Zukunft</span> der Gesundheitsversorgung</span><br/>
+           <span>beginnt mit der richtigen Analyse</span>
           </span>
           <span class="lang lang-en" hidden>The digital future of healthcare<br/>begins with the right analysis</span>
         </h1>


### PR DESCRIPTION
## Summary
- allow hero heading and tagline to wrap to prevent overflow on mobile
- remove no-wrap spans so German text no longer widens the page

## Testing
- `npx --yes htmlhint index.html datenschutz.html impressum.html`

------
https://chatgpt.com/codex/tasks/task_e_68b1ae28b54883269ee4bea4ebe83fbd