### PR TITLE
Hide English hero headline by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -573,7 +573,7 @@
             <span class="no-wrap">Die <span class="accent">digitale Zukunft</span> der Gesundheitsversorgung</span><br/>
             <span class="no-wrap">beginnt mit der richtigen Analyse</span>
           </span>
-          <span class="lang lang-en">
+          <span class="lang lang-en" hidden>
             <span class="no-wrap">The <span class="accent">digital future</span> of healthcare</span><br/>
             <span class="no-wrap">begins with the right analysis</span>
           </span>


### PR DESCRIPTION
## Summary
- ensure English hero tagline is hidden initially so the page loads in a single language

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b37efba083268fc933f2a1bc7f91