### PR TITLE
Prevent line breaks in instrument section headings on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -1232,6 +1232,7 @@
 
   @media (min-width:1024px){
     #instrument{ padding:4rem 2rem; }
+    #instrument .benefit-content h3{ white-space:nowrap; }
   }
 
   @media (max-width:700px){


### PR DESCRIPTION
## Summary
- Prevent analysis instrument benefit headings from wrapping on desktop

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ba28f2b08326a4e7ea3f37460e2e