### PR TITLE
Refine analysedimensionen card typography and icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1328,6 +1328,35 @@
   #dimensionen .dim-card {
     height: 100%;
   }
+  /* Icon design aligned with pitch section */
+  #dimensionen .dim-icon-ring{
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    width:48px;
+    height:48px;
+    margin:0 auto .75rem;
+    border-radius:50%;
+    background:rgba(37,88,235,.12);
+  }
+  #dimensionen .dim-icon-ring img,
+  #dimensionen .dim-icon-ring svg{
+    width:28px;
+    height:28px;
+    color:var(--accent);
+  }
+  /* Larger typography for cards */
+  #dimensionen .dim-card h3{
+    text-align:center;
+    font-size:1.25rem;
+    font-weight:600;
+  }
+  #dimensionen .dim-card p{
+    text-align:center;
+    font-size:1.05rem;
+    line-height:1.5;
+    color:#475569;
+  }
   /* „Mehr erfahren“-Button in Karten */
   #dimensionen .dim-more-btn {
     display: inline-flex;
@@ -1358,7 +1387,7 @@
         <!-- Vorderseite -->
         <article class="flip-card-front dim-card">
          <div class="dim-icon-ring">
-          <img alt="Icon Arbeitsprozesse" data-alt-en="Icon Work processes" decoding="async" height="22" loading="lazy" src="assets/icons/workload.svg" width="22"/>
+          <img alt="Icon Arbeitsprozesse" data-alt-en="Icon Work processes" decoding="async" height="28" loading="lazy" src="assets/icons/workload.svg" width="28"/>
          </div>
          <h3>
           <span class="lang lang-de">
@@ -1388,7 +1417,7 @@
         <!-- Rückseite -->
         <article class="flip-card-back dim-card">
          <div class="dim-icon-ring">
-          <img alt="Icon Arbeitsprozesse" data-alt-en="Icon Work processes" decoding="async" height="22" loading="lazy" src="assets/icons/workload.svg" width="22"/>
+          <img alt="Icon Arbeitsprozesse" data-alt-en="Icon Work processes" decoding="async" height="28" loading="lazy" src="assets/icons/workload.svg" width="28"/>
          </div>
          <h3>
           <span class="lang lang-de">
@@ -1414,7 +1443,7 @@
        <div class="flip-card-inner">
         <article class="flip-card-front dim-card">
          <div class="dim-icon-ring">
-          <img alt="Icon Systemqualität" data-alt-en="Icon System quality" decoding="async" height="22" loading="lazy" src="assets/icons/system-quality.svg" width="22"/>
+          <img alt="Icon Systemqualität" data-alt-en="Icon System quality" decoding="async" height="28" loading="lazy" src="assets/icons/system-quality.svg" width="28"/>
          </div>
          <h3>
           <span class="lang lang-de">
@@ -1443,7 +1472,7 @@
         </article>
         <article class="flip-card-back dim-card">
          <div class="dim-icon-ring">
-          <img alt="Icon Systemqualität" data-alt-en="Icon System quality" decoding="async" height="22" loading="lazy" src="assets/icons/system-quality.svg" width="22"/>
+          <img alt="Icon Systemqualität" data-alt-en="Icon System quality" decoding="async" height="28" loading="lazy" src="assets/icons/system-quality.svg" width="28"/>
          </div>
          <h3>
           <span class="lang lang-de">
@@ -1469,7 +1498,7 @@
        <div class="flip-card-inner">
         <article class="flip-card-front dim-card">
          <div class="dim-icon-ring">
-          <img alt="Icon Informationsqualität" data-alt-en="Icon Information quality" decoding="async" height="22" loading="lazy" src="assets/icons/info-quality.svg" width="22"/>
+          <img alt="Icon Informationsqualität" data-alt-en="Icon Information quality" decoding="async" height="28" loading="lazy" src="assets/icons/info-quality.svg" width="28"/>
          </div>
          <h3>
           <span class="lang lang-de">
@@ -1498,7 +1527,7 @@
         </article>
         <article class="flip-card-back dim-card">
          <div class="dim-icon-ring">
-          <img alt="Icon Informationsqualität" data-alt-en="Icon Information quality" decoding="async" height="22" loading="lazy" src="assets/icons/info-quality.svg" width="22"/>
+          <img alt="Icon Informationsqualität" data-alt-en="Icon Information quality" decoding="async" height="28" loading="lazy" src="assets/icons/info-quality.svg" width="28"/>
          </div>
          <h3>
           <span class="lang lang-de">
@@ -1524,7 +1553,7 @@
        <div class="flip-card-inner">
         <article class="flip-card-front dim-card">
          <div class="dim-icon-ring">
-          <img alt="Icon Kommunikation &amp; Kollaboration" data-alt-en="Icon Communication &amp; Collaboration" decoding="async" height="22" loading="lazy" src="assets/icons/communication.svg" width="22"/>
+          <img alt="Icon Kommunikation &amp; Kollaboration" data-alt-en="Icon Communication &amp; Collaboration" decoding="async" height="28" loading="lazy" src="assets/icons/communication.svg" width="28"/>
          </div>
          <h3>
           <span class="lang lang-de">
@@ -1553,7 +1582,7 @@
         </article>
         <article class="flip-card-back dim-card">
          <div class="dim-icon-ring">
-          <img alt="Icon Kommunikation &amp; Kollaboration" data-alt-en="Icon Communication &amp; Collaboration" decoding="async" height="22" loading="lazy" src="assets/icons/communication.svg" width="22"/>
+          <img alt="Icon Kommunikation &amp; Kollaboration" data-alt-en="Icon Communication &amp; Collaboration" decoding="async" height="28" loading="lazy" src="assets/icons/communication.svg" width="28"/>
          </div>
          <h3>
           <span class="lang lang-de">
@@ -1579,7 +1608,7 @@
        <div class="flip-card-inner">
         <article class="flip-card-front dim-card">
          <div class="dim-icon-ring">
-          <img alt="Icon Nutzerzufriedenheit" data-alt-en="Icon User satisfaction" decoding="async" height="22" loading="lazy" src="assets/icons/satisfaction.svg" width="22"/>
+          <img alt="Icon Nutzerzufriedenheit" data-alt-en="Icon User satisfaction" decoding="async" height="28" loading="lazy" src="assets/icons/satisfaction.svg" width="28"/>
          </div>
          <h3>
           <span class="lang lang-de">
@@ -1608,7 +1637,7 @@
         </article>
         <article class="flip-card-back dim-card">
          <div class="dim-icon-ring">
-          <img alt="Icon Nutzerzufriedenheit" data-alt-en="Icon User satisfaction" decoding="async" height="22" loading="lazy" src="assets/icons/satisfaction.svg" width="22"/>
+          <img alt="Icon Nutzerzufriedenheit" data-alt-en="Icon User satisfaction" decoding="async" height="28" loading="lazy" src="assets/icons/satisfaction.svg" width="28"/>
          </div>
          <h3>
           <span class="lang lang-de">
@@ -1634,7 +1663,7 @@
        <div class="flip-card-inner">
         <article class="flip-card-front dim-card">
          <div class="dim-icon-ring">
-          <img alt="Icon Arbeitsbelastung" data-alt-en="Icon Workload" decoding="async" height="22" loading="lazy" src="assets/icons/workload-alt.svg" width="22"/>
+          <img alt="Icon Arbeitsbelastung" data-alt-en="Icon Workload" decoding="async" height="28" loading="lazy" src="assets/icons/workload-alt.svg" width="28"/>
          </div>
          <h3>
           <span class="lang lang-de">
@@ -1663,7 +1692,7 @@
         </article>
         <article class="flip-card-back dim-card">
          <div class="dim-icon-ring">
-          <img alt="Icon Arbeitsbelastung" data-alt-en="Icon Workload" decoding="async" height="22" loading="lazy" src="assets/icons/workload-alt.svg" width="22"/>
+          <img alt="Icon Arbeitsbelastung" data-alt-en="Icon Workload" decoding="async" height="28" loading="lazy" src="assets/icons/workload-alt.svg" width="28"/>
          </div>
          <h3>
           <span class="lang lang-de">
@@ -1970,7 +1999,7 @@
   <footer class="legal-footer">
    <div class="footer-brand">
     <a aria-label="Zum Seitenanfang" class="footer-logo-link" href="#top">
-     <img alt="IMHIS Logo" class="footer-logo" height="22" src="assets/Logo_blau.svg" width="120"/>
+     <img alt="IMHIS Logo" class="footer-logo" height="28" src="assets/Logo_blau.svg" width="120"/>
     </a>
     <a aria-label="LinkedIn" class="social-link" href="https://www.linkedin.com/in/imhis/" rel="noopener noreferrer" target="_blank">
      <svg aria-hidden="true" fill="currentColor" height="24" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
- Increase analysedimension card heading and body text to better align with pitch typography
- Restyle dimension icons with centered layout and pitch-style circular background

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d4308d40832685d972538ad49414