### PR TITLE
Align section typography with pitch and center dimension buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1198,9 +1198,13 @@
     text-align:left;
   }
 
-  #instrument-title{
-    margin:0 0 1rem; font-weight:800; color:var(--brand);
-    font-size:clamp(1.6rem,2.4vw,2rem); line-height:1.3;
+ #instrument-title{
+    margin:0 0 .6rem;
+    font-weight:700;
+    color:#172554;
+    font-size:clamp(1.6rem,2.2vw,2rem);
+    line-height:1.3;
+    letter-spacing:-.01em;
   }
   #instrument .body{
     margin:0 0 1.5rem; color:#475569; font-size:clamp(1rem,1.4vw,1.125rem); line-height:1.55;
@@ -1362,7 +1366,7 @@
     display: inline-flex;
     align-items: center;
     gap: .6rem;
-    align-self: flex-start;
+    align-self: center;
     margin-top: auto;
     padding: 1rem 1.5rem;
     border: none;

--- a/styles/main.css
+++ b/styles/main.css
@@ -253,13 +253,6 @@ footer a {
     margin-bottom: 1.5rem;
 }
 
-#instrument p {
-    font-size: 1.125rem;
-}
-#instrument p.eyebrow {
-    font-size: .85rem;
-}
-
 .content {
     max-width: 960px;
     margin: 0 auto;
@@ -394,13 +387,16 @@ footer a {
 .book-info h2 {
     color: #172554;
     font-weight: 700;
-    font-size: 1.75rem;
-    margin-bottom: 1rem;
+    font-size: clamp(1.6rem, 2.2vw, 2rem);
+    margin-bottom: .6rem;
+    letter-spacing: -0.01em;
 }
 
 .book-subline {
-    color: #172554cc;
+    color: #1e293b;
     font-weight: 400;
+    font-size: clamp(1.3rem, 2.3vw, 1.65rem);
+    line-height: 1.55;
     max-width: 600px;
     margin-bottom: 1.25rem;
 }
@@ -1417,6 +1413,14 @@ header {
 /* gleicher Block-Abstand im Flow wie bei Dimensionen↔Buch */
 .li-section {
     margin: 0 auto 1.25rem;
+}
+
+.li-section h2 {
+    color: #172554;
+    font-weight: 700;
+    font-size: clamp(1.6rem, 2.2vw, 2rem);
+    margin: 0 0 .6rem;
+    letter-spacing: -0.01em;
 }
 
 @media (min-width:1024px) {


### PR DESCRIPTION
## Summary
- Centered "Mehr erfahren" buttons inside analysis dimension cards for a balanced layout.
- Unified heading and subline typography in Analyseinstrument, LinkedIn, and book sections to match the pitch section’s style.

## Testing
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b1d5fbdbbc8326a045cfa01dade655