### PR TITLE
Add complementary hero highlight for analysis phrase

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,6 +323,11 @@
         background: linear-gradient(90deg, rgba(37,99,235,.14), rgba(37,99,235,.06));
       }
 
+      /* Variant underline for complementary hero highlight */
+      .hero .accent-alt::after {
+        background: linear-gradient(90deg, rgba(37,99,235,.06), rgba(37,99,235,.14));
+      }
+
       .hero-tagline {
         margin-top: 1rem;
         font-size: 1.5rem;
@@ -571,11 +576,11 @@
         <h1>
           <span class="lang lang-de">
             <span class="no-wrap">Die <span class="accent">digitale Zukunft</span> der Gesundheitsversorgung</span><br/>
-            <span class="no-wrap">beginnt mit der richtigen Analyse</span>
+            <span class="no-wrap">beginnt mit der <span class="accent accent-alt">richtigen Analyse</span></span>
           </span>
           <span class="lang lang-en" hidden>
             <span class="no-wrap">The <span class="accent">digital future</span> of healthcare</span><br/>
-            <span class="no-wrap">begins with the right analysis</span>
+            <span class="no-wrap">begins with the <span class="accent accent-alt">right analysis</span></span>
           </span>
         </h1>
          <p>


### PR DESCRIPTION
## Summary
- Emphasize "richtige Analyse" and its English counterpart in the hero section with a secondary gradient underline
- Introduce `.accent-alt` styling to mirror the existing highlight while keeping visual cohesion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1df5f19288326958d2841b7d34a73