### PR TITLE
Add dedicated Florian Eisold profile page and SEO improvements

### DIFF
--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Informationen über Dr. Florian Eisold, Arzt und Entwickler von IMHIS." />
+    <meta name="keywords" content="Florian Eisold, IMHIS, Arzt, Entwickler" />
+    <title>Dr. Florian Eisold – IMHIS</title>
+    <meta name="author" content="Florian Eisold" />
+    <meta name="theme-color" content="#0f172a" />
+    <link rel="canonical" href="https://imhis.de/florian-eisold.html" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="styles/main.min.css" />
+    <meta property="og:title" content="Dr. Florian Eisold – IMHIS" />
+    <meta property="og:description" content="Informationen über Dr. Florian Eisold, Arzt und Entwickler von IMHIS." />
+    <meta property="og:url" content="https://imhis.de/florian-eisold.html" />
+    <meta property="og:type" content="profile" />
+    <meta property="og:image" content="https://imhis.de/assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg" />
+    <meta property="og:image:alt" content="Dr. Florian Eisold" />
+    <meta property="og:site_name" content="IMHIS" />
+    <meta property="og:locale" content="de_DE" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Dr. Florian Eisold – IMHIS" />
+    <meta name="twitter:description" content="Informationen über Dr. Florian Eisold, Arzt und Entwickler von IMHIS." />
+    <meta name="twitter:image" content="https://imhis.de/assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg" />
+    <meta name="twitter:image:alt" content="Dr. Florian Eisold" />
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Dr. Florian Eisold",
+      "jobTitle": "Arzt und Entwickler von IMHIS",
+      "url": "https://imhis.de/florian-eisold.html",
+      "image": "https://imhis.de/assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg",
+      "affiliation": {
+        "@type": "Organization",
+        "name": "IMHIS – Impact Monitor for Health Information Systems",
+        "url": "https://imhis.de/"
+      }
+    }
+    </script>
+  </head>
+  <body>
+    <main class="legal-content">
+      <h1>Dr. Florian Eisold</h1>
+      <p>Dr. med. Florian Eisold, B.Sc., LL.M., ist Arzt und der Entwickler von IMHIS – Impact Monitor for Health Information Systems. Er setzt sich für eine nutzerzentrierte Digitalisierung im Gesundheitswesen ein und ist Autor des Buchs „Digitale Systeme – echte Wirkung: Was Klinikpersonal wirklich braucht“.</p>
+    </main>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -7,12 +7,13 @@
    IMHIS – Impact Monitor for Health Information Systems
   </title>
   <meta content="IMHIS ist ein Analyseinstrument zur nutzerzentrierten Bewertung von Gesundheitsinformationssystemen." name="description"/>
-  <meta content="Gesundheitsinformationssysteme, digitale Medizin, Analyseinstrument" name="keywords"/>
+  <meta content="Florian Eisold, Gesundheitsinformationssysteme, digitale Medizin, Analyseinstrument" name="keywords"/>
   <meta content="index, follow" name="robots"/>
   <meta content="Florian Eisold" name="author"/>
   <meta content="#0f172a" name="theme-color"/>
   <meta content="light dark" name="color-scheme"/>
   <link href="https://imhis.de/" rel="canonical"/>
+  <link href="https://imhis.de/florian-eisold.html" rel="author"/>
   <link href="/sitemap.xml" rel="sitemap" type="application/xml"/>
   <meta content="IMHIS – Impact Monitor for Health Information Systems" property="og:title"/>
   <meta content="IMHIS ist ein Analyseinstrument zur nutzerzentrierten Bewertung von Gesundheitsinformationssystemen." property="og:description"/>
@@ -1016,8 +1017,8 @@
       </blockquote>
 
       <cite class="about-cite">
-        <span class="lang lang-de">Dr. med. Florian Eisold, B.Sc., LL.M. – Arzt und Entwickler von IMHIS</span>
-        <span class="lang lang-en" hidden>Dr. Florian Eisold, M.D., B.Sc., LL.M. – physician and developer of IMHIS</span>
+        <span class="lang lang-de"><a href="florian-eisold.html">Dr. med. Florian Eisold, B.Sc., LL.M.</a> – Arzt und Entwickler von IMHIS</span>
+        <span class="lang lang-en" hidden><a href="florian-eisold.html">Dr. Florian Eisold, M.D., B.Sc., LL.M.</a> – physician and developer of IMHIS</span>
       </cite>
 
       <a class="btn-primary about-cta" href="mailto:florianeisold@outlook.de">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,8 +2,14 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://imhis.de/</loc>
-    <lastmod>2025-08-12</lastmod>
+    <lastmod>2025-08-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://imhis.de/florian-eisold.html</loc>
+    <lastmod>2025-08-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add `florian-eisold.html` profile page with metadata and structured data
- link to profile from home page and include name in keywords
- update sitemap to reference new page

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1f0cee6148326afcc0b073dc49982