### PR TITLE
Improve logo image accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -427,7 +427,7 @@
   <header>
    <nav aria-label="Hauptnavigation" class="nav">
     <a aria-label="IMHIS Startseite" class="logo" href="#top">
-     <img alt="IMHIS Logo" decoding="async" fetchpriority="high" height="74" src="assets/Logo_blau.svg" width="398"/>
+     <img alt="IMHIS Logo" data-alt-en="IMHIS logo" decoding="async" fetchpriority="high" height="74" src="assets/Logo_blau.svg" width="398"/>
     </a>
     <!-- Language Switcher (Mobile) -->
     <div aria-label="Sprachauswahl" class="lang-switcher lang-switcher--mobile" role="group">
@@ -2021,7 +2021,7 @@
   <footer class="legal-footer">
    <div class="footer-brand">
     <a aria-label="Zum Seitenanfang" class="footer-logo-link" href="#top">
-     <img alt="IMHIS Logo" class="footer-logo" height="28" src="assets/Logo_blau.svg" width="120"/>
+     <img alt="IMHIS Logo" class="footer-logo" data-alt-en="IMHIS logo" decoding="async" loading="lazy" height="28" src="assets/Logo_blau.svg" width="120"/>
     </a>
     <a aria-label="LinkedIn" class="social-link" href="https://www.linkedin.com/in/imhis/" rel="noopener noreferrer" target="_blank">
      <svg aria-hidden="true" fill="currentColor" height="24" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
- add English alt text data attributes to header and footer logos
- lazy-load footer logo to reduce initial payload

## Testing
- `npx htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68b1f303001c832696b58b672044d460