### PR TITLE
Add header, footer and SEO tweaks to Florian Eisold profile page

### DIFF
--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -5,14 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Informationen über Dr. Florian Eisold, Arzt und Entwickler von IMHIS." />
     <meta name="keywords" content="Florian Eisold, IMHIS, Arzt, Entwickler" />
-    <title>Dr. Florian Eisold – IMHIS</title>
     <meta name="author" content="Florian Eisold" />
     <meta name="theme-color" content="#0f172a" />
+    <meta name="robots" content="index,follow" />
+    <title>Dr. Florian Eisold – IMHIS</title>
     <link rel="canonical" href="https://imhis.de/florian-eisold.html" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="styles/main.min.css" />
+
     <meta property="og:title" content="Dr. Florian Eisold – IMHIS" />
     <meta property="og:description" content="Informationen über Dr. Florian Eisold, Arzt und Entwickler von IMHIS." />
     <meta property="og:url" content="https://imhis.de/florian-eisold.html" />
@@ -26,6 +24,37 @@
     <meta name="twitter:description" content="Informationen über Dr. Florian Eisold, Arzt und Entwickler von IMHIS." />
     <meta name="twitter:image" content="https://imhis.de/assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg" />
     <meta name="twitter:image:alt" content="Dr. Florian Eisold" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      as="font"
+      href="https://fonts.gstatic.com/s/inter/v19/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2"
+      type="font/woff2"
+      crossorigin
+      fetchpriority="high"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="preload"
+      href="styles/main.min.css"
+      as="style"
+      onload="this.onload=null;this.rel='stylesheet'"
+    />
+    <noscript><link rel="stylesheet" href="styles/main.min.css" /></noscript>
+
+    <link rel="preload" href="assets/Logo_blau.svg" as="image" type="image/svg+xml" />
+
+    <link rel="icon" href="/assets/icons/favicon.ico" sizes="any" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/assets/icons/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png" />
+    <link rel="manifest" href="/assets/icons/site.webmanifest" />
+
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -43,12 +72,123 @@
     </script>
   </head>
   <body>
-    <main class="legal-content">
+    <a class="skip-link" href="#main-content">
+      <span class="lang lang-de">Zum Inhalt springen</span>
+      <span class="lang lang-en" hidden>Skip to content</span>
+    </a>
+    <header>
+      <nav class="nav">
+        <a href="/index.html#top" class="logo" aria-label="IMHIS Startseite">
+          <img
+            src="assets/Logo_blau.svg"
+            alt="IMHIS Logo"
+            decoding="async"
+            fetchpriority="high"
+            width="398"
+            height="74"
+          />
+        </a>
+        <div class="lang-switcher lang-switcher--mobile" role="group" aria-label="Sprachauswahl">
+          <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
+          <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
+        </div>
+        <button
+          class="nav-toggle"
+          aria-label="Menü öffnen"
+          aria-expanded="false"
+          aria-controls="nav-links"
+          data-label-open-de="Menü öffnen"
+          data-label-close-de="Menü schließen"
+          data-label-open-en="Open menu"
+          data-label-close-en="Close menu"
+        >
+          <span class="hamburger"></span>
+        </button>
+        <ul class="nav-links" id="nav-links" hidden>
+          <li>
+            <a href="/index.html#pitch">
+              <span class="lang lang-de">Echte Wirkung</span>
+              <span class="lang lang-en" hidden>Real impact</span>
+            </a>
+          </li>
+          <li>
+            <a href="/index.html#instrument">
+              <span class="lang lang-de">Analyseinstrument</span>
+              <span class="lang lang-en" hidden>Assessment Tool</span>
+            </a>
+          </li>
+          <li>
+            <a href="/index.html#linkedin">
+              <span class="lang lang-de">News</span>
+              <span class="lang lang-en" hidden>News</span>
+            </a>
+          </li>
+          <li class="lang-switcher lang-switcher--desktop" role="group" aria-label="Sprachauswahl">
+            <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
+            <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
+          </li>
+          <li class="nav-actions--mobile">
+            <a href="/index.html#buch" class="btn-secondary">
+              <span class="lang lang-de">Buch ansehen</span>
+              <span class="lang lang-en" hidden>View book</span>
+            </a>
+            <a href="mailto:florianeisold@outlook.de" class="btn-primary">
+              <span class="lang lang-de">Kostenlos anfragen</span>
+              <span class="lang lang-en" hidden>Request (free)</span>
+            </a>
+          </li>
+        </ul>
+        <div class="nav-actions">
+          <a href="/index.html#buch" class="btn-secondary">
+            <span class="lang lang-de">Buch ansehen</span>
+            <span class="lang lang-en" hidden>View book</span>
+          </a>
+          <a href="mailto:florianeisold@outlook.de" class="btn-primary">
+            <span class="lang lang-de">Kostenlos anfragen</span>
+            <span class="lang lang-en" hidden>Request (free)</span>
+          </a>
+        </div>
+      </nav>
+    </header>
+
+    <main id="main-content" class="content legal-content">
       <h1>Dr. Florian Eisold</h1>
-      <p>Dr. med. Florian Eisold, B.Sc., LL.M., ist Arzt und der Entwickler von IMHIS – Impact Monitor for Health Information Systems. Er setzt sich für eine nutzerzentrierte Digitalisierung im Gesundheitswesen ein und ist Autor des Buchs „Digitale Systeme – echte Wirkung: Was Klinikpersonal wirklich braucht“.</p>
-    </main>
-  </body>
-    <p class="back-home">
-        <a href="/index.html">← Zurück zur Startseite</a>
+      <figure class="about-img" aria-hidden="true">
+        <img
+          src="assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg"
+          alt="Dr. Florian Eisold"
+          decoding="async"
+          loading="lazy"
+          width="200"
+          height="200"
+        />
+      </figure>
+      <p>
+        Dr. med. Florian Eisold, B.Sc., LL.M., ist Arzt und der Entwickler von IMHIS – Impact Monitor for Health Information Systems.
+        Er setzt sich für eine nutzerzentrierte Digitalisierung im Gesundheitswesen ein und ist Autor des Buchs „Digitale Systeme – echte Wirkung: Was Klinikpersonal wirklich braucht“.
       </p>
+    </main>
+
+    <footer id="kontakt" class="contact-footer">
+      <a href="mailto:florianeisold@outlook.de" class="cta">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <rect x="3" y="5" width="18" height="14" rx="2" ry="2" stroke="currentColor" stroke-width="2" stroke-linejoin="round" />
+          <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+        Analyse geplant?
+      </a>
+    </footer>
+    <footer class="legal-footer">
+      <div class="legal-links">
+        <a href="/impressum.html">Impressum</a>
+        <a href="/datenschutz.html">Datenschutz</a>
+      </div>
+      <p class="copyright">
+        © 2025 IMHIS – Damit Digitalisierung wirkt. Inhalte urheberrechtlich geschützt. Für Kooperationen oder Nutzungsanfragen:
+        <a href="mailto:florianeisold@outlook.de">florianeisold@outlook.de</a>
+      </p>
+    </footer>
+
+    <script src="scripts/main.min.js" defer></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Add global site header with navigation and language switcher to `florian-eisold.html`
- Insert profile photo and description of Dr. Florian Eisold
- Append contact and legal footers; preload fonts and styles for SEO and performance

## Testing
- `npx htmlhint florian-eisold.html`


------
https://chatgpt.com/codex/tasks/task_e_68b1fbd5c1c88326b0ddefbaf6ba5c26