### PR TITLE
feat: style Florian Eisold page with about section layout

### DIFF
--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -151,22 +151,45 @@
       </nav>
     </header>
 
-    <main id="main-content" class="content legal-content">
-      <h1>Dr. Florian Eisold</h1>
-      <figure class="about-img" aria-hidden="true">
-        <img
-          src="assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg"
-          alt="Dr. Florian Eisold"
-          decoding="async"
-          loading="lazy"
-          width="200"
-          height="200"
-        />
-      </figure>
-      <p>
-        Dr. med. Florian Eisold, B.Sc., LL.M., ist Arzt und der Entwickler von IMHIS – Impact Monitor for Health Information Systems.
-        Er setzt sich für eine nutzerzentrierte Digitalisierung im Gesundheitswesen ein und ist Autor des Buchs „Digitale Systeme – echte Wirkung: Was Klinikpersonal wirklich braucht“.
-      </p>
+    <main id="main-content" class="content">
+      <section class="section about-me-section" aria-labelledby="about-title">
+        <div class="about-wrap">
+          <figure class="about-img" aria-hidden="true">
+            <img
+              src="assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg"
+              alt="Dr. Florian Eisold"
+              decoding="async"
+              loading="lazy"
+              width="200"
+              height="200"
+            />
+          </figure>
+
+          <div class="about-content">
+            <h1 id="about-title">Dr. Florian Eisold</h1>
+            <p>
+              Dr. med. Florian Eisold, B.Sc., LL.M., ist Arzt und der Entwickler von IMHIS – Impact Monitor for Health Information Systems.
+              Er setzt sich für eine nutzerzentrierte Digitalisierung im Gesundheitswesen ein und ist Autor des Buchs „Digitale Systeme – echte Wirkung: Was Klinikpersonal wirklich braucht“.
+            </p>
+            <a
+              class="btn-primary about-cta"
+              href="https://link.springer.com/book/9783658491895"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Jetzt lesen
+            </a>
+            <a
+              class="btn-secondary about-cta"
+              href="https://www.linkedin.com/in/dr-med-florian-r-eisold-b-sc-ll-m-7a4a08145/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              LinkedIn Kontakt aufnehmen
+            </a>
+          </div>
+        </div>
+      </section>
     </main>
 
     <footer id="kontakt" class="contact-footer">


### PR DESCRIPTION
## Summary
- Apply about-me section layout to Florian Eisold profile
- Add Springer "Jetzt lesen" and LinkedIn contact buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fd8381688326bdc4ef9822532d4d