### PR TITLE
chore: improve AI SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
   <title>
    IMHIS – Impact Monitor for Health Information Systems
   </title>
-  <meta content="IMHIS – entwickelt von Dr. Florian Eisold – ist ein Analyseinstrument zur nutzerzentrierten Bewertung von Gesundheitsinformationssystemen." name="description"/>
-  <meta content="Florian Eisold, Gesundheitsinformationssysteme, digitale Medizin, Analyseinstrument" name="keywords"/>
-  <meta content="index, follow" name="robots"/>
+  <meta name="description" content="IMHIS – entwickelt von Dr. Florian Eisold – ist ein Analyseinstrument zur nutzerzentrierten Bewertung von Gesundheitsinformationssystemen und bietet Einblicke für KI-Agenten und ChatGPT-Suchanfragen."/>
+  <meta name="keywords" content="Florian Eisold, Gesundheitsinformationssysteme, digitale Medizin, Analyseinstrument, KI-Agenten, AI agents, ChatGPT, Künstliche Intelligenz"/>
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1"/>
   <meta content="Florian Eisold" name="author"/>
   <meta content="#0f172a" name="theme-color"/>
   <meta content="light dark" name="color-scheme"/>
@@ -16,7 +16,7 @@
   <link href="https://imhis.de/florian-eisold.html" rel="author"/>
   <link href="/sitemap.xml" rel="sitemap" type="application/xml"/>
   <meta content="IMHIS – Impact Monitor for Health Information Systems" property="og:title"/>
-  <meta content="IMHIS ist ein Analyseinstrument zur nutzerzentrierten Bewertung von Gesundheitsinformationssystemen." property="og:description"/>
+  <meta content="IMHIS ist ein Analyseinstrument zur nutzerzentrierten Bewertung von Gesundheitsinformationssystemen und bietet Einblicke für KI-Agenten und ChatGPT-Suchanfragen." property="og:description"/>
   <meta content="https://imhis.de/" property="og:url"/>
   <meta content="website" property="og:type"/>
   <meta content="https://imhis.de/assets/Logo_blau.svg" property="og:image"/>
@@ -24,7 +24,7 @@
   <meta content="summary" name="twitter:card"/>
   <meta content="https://imhis.de/assets/Logo_blau.svg" name="twitter:image"/>
   <meta content="IMHIS – Impact Monitor for Health Information Systems" name="twitter:title"/>
-  <meta content="IMHIS ist ein Analyseinstrument zur nutzerzentrierten Bewertung von Gesundheitsinformationssystemen." name="twitter:description"/>
+  <meta content="IMHIS ist ein Analyseinstrument zur nutzerzentrierten Bewertung von Gesundheitsinformationssystemen und bietet Einblicke für KI-Agenten und ChatGPT-Suchanfragen." name="twitter:description"/>
   <meta content="IMHIS Logo" name="twitter:image:alt"/>
   <meta content="IMHIS" property="og:site_name"/>
   <meta content="de_DE" property="og:locale"/>

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,15 @@
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
 User-agent: *
 Allow: /
 Disallow: /impressum.html


### PR DESCRIPTION
## Summary
- add AI- and ChatGPT-focused metadata to help search and crawling
- allow extended snippets via robots meta tags
- explicitly permit GPTBot, OAI-SearchBot, ChatGPT-User and Google-Extended in robots.txt

## Testing
- `npx --yes htmlhint index.html`
- `npx htmlhint robots.txt`


------
https://chatgpt.com/codex/tasks/task_e_68b201f577e08326a55e8e0dafa7ade2