### PR TITLE
Consolidate language toggle in navigation

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -114,10 +114,6 @@
             height="74"
           />
         </a>
-        <div class="lang-switcher lang-switcher--mobile" role="group" aria-label="Sprachauswahl">
-          <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
-          <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
-        </div>
         <button
           class="nav-toggle"
           aria-label="Menü öffnen"
@@ -149,7 +145,7 @@
               <span class="lang lang-en" hidden>News</span>
             </a>
           </li>
-          <li class="lang-switcher lang-switcher--desktop" role="group" aria-label="Sprachauswahl">
+          <li class="lang-switcher" role="group" aria-label="Sprachauswahl">
             <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
             <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
           </li>

--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -92,10 +92,6 @@
             height="74"
           />
         </a>
-        <div class="lang-switcher lang-switcher--mobile" role="group" aria-label="Sprachauswahl">
-          <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
-          <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
-        </div>
         <button
           class="nav-toggle"
           aria-label="Menü öffnen"
@@ -127,7 +123,7 @@
               <span class="lang lang-en" hidden>News</span>
             </a>
           </li>
-          <li class="lang-switcher lang-switcher--desktop" role="group" aria-label="Sprachauswahl">
+          <li class="lang-switcher" role="group" aria-label="Sprachauswahl">
             <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
             <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
           </li>

--- a/impressum.html
+++ b/impressum.html
@@ -94,10 +94,6 @@
             height="74"
           />
         </a>
-        <div class="lang-switcher lang-switcher--mobile" role="group" aria-label="Sprachauswahl">
-          <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
-          <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
-        </div>
         <button
           class="nav-toggle"
           aria-label="Menü öffnen"
@@ -129,7 +125,7 @@
               <span class="lang lang-en" hidden>News</span>
             </a>
           </li>
-          <li class="lang-switcher lang-switcher--desktop" role="group" aria-label="Sprachauswahl">
+          <li class="lang-switcher" role="group" aria-label="Sprachauswahl">
             <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
             <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
           </li>

--- a/index.html
+++ b/index.html
@@ -465,15 +465,6 @@
     <a aria-label="IMHIS Startseite" class="logo" href="#top">
      <img alt="IMHIS Logo" data-alt-en="IMHIS logo" decoding="async" fetchpriority="high" height="74" src="assets/Logo_blau.svg" width="398"/>
     </a>
-    <!-- Language Switcher (Mobile) -->
-    <div aria-label="Sprachauswahl" class="lang-switcher lang-switcher--mobile" role="group">
-     <button aria-label="Deutsch" aria-pressed="true" class="lang-btn" data-lang="de">
-      DE
-     </button>
-     <button aria-label="English" aria-pressed="false" class="lang-btn" data-lang="en">
-      EN
-     </button>
-    </div>
     <!-- Hamburger bleibt für dein bestehendes JS -->
     <button aria-controls="nav-links" aria-expanded="false" aria-label="Menü öffnen" class="nav-toggle" data-label-close-de="Menü schließen" data-label-close-en="Close menu" data-label-open-de="Menü öffnen" data-label-open-en="Open menu">
      <span class="hamburger">
@@ -511,8 +502,7 @@
        </span>
       </a>
      </li>
-     <!-- Language Switcher (Desktop) -->
-     <li aria-label="Sprachauswahl" class="lang-switcher lang-switcher--desktop" role="group">
+     <li aria-label="Sprachauswahl" class="lang-switcher" role="group">
       <button aria-label="Deutsch" aria-pressed="true" class="lang-btn" data-lang="de">
        DE
       </button>


### PR DESCRIPTION
## Summary
- Remove redundant mobile language switcher and keep a single toggle in navigation across all pages

## Testing
- `npx --yes htmlhint index.html florian-eisold.html datenschutz.html impressum.html`

------
https://chatgpt.com/codex/tasks/task_e_68b2ab2f3bec8326bfdda98e5b8fa058