### PR TITLE
Improve mobile nav language toggle and CTA styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -465,6 +465,10 @@
     <a aria-label="IMHIS Startseite" class="logo" href="#top">
      <img alt="IMHIS Logo" data-alt-en="IMHIS logo" decoding="async" fetchpriority="high" height="74" src="assets/Logo_blau.svg" width="398"/>
     </a>
+    <div aria-label="Sprachauswahl" class="lang-switcher lang-switcher--mobile" role="group">
+     <button aria-label="Deutsch" aria-pressed="true" class="lang-btn" data-lang="de">DE</button>
+     <button aria-label="English" aria-pressed="false" class="lang-btn" data-lang="en">EN</button>
+    </div>
     <!-- Hamburger bleibt für dein bestehendes JS -->
     <button aria-controls="nav-links" aria-expanded="false" aria-label="Menü öffnen" class="nav-toggle" data-label-close-de="Menü schließen" data-label-close-en="Close menu" data-label-open-de="Menü öffnen" data-label-open-en="Open menu">
      <span class="hamburger">

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -58,3 +58,26 @@
   color: var(--link);
 }
 
+.lang-switcher--mobile {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .lang-switcher--mobile {
+    display: inline-flex;
+    margin-right: 1rem;
+  }
+  .nav-links .lang-switcher {
+    display: none;
+  }
+  .nav-actions--mobile {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .nav-actions--mobile .btn {
+    width: 100%;
+    text-align: center;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Expose language switcher next to hamburger on small screens
- Style mobile menu actions with CTA button design

## Testing
- `npx -y htmlhint index.html`
- `npx -y stylelint styles/custom.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b2af23e3b883268acde30ca6cd7cbb