### PR TITLE
style: align language toggle color across viewports

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -50,6 +50,13 @@
 
 .lang-btn[aria-pressed="true"] {
   background: var(--link);
+  border-color: var(--link);
+  color: #fff;
+}
+
+.nav-links button.lang-btn[aria-pressed="true"] {
+  background: var(--link);
+  border-color: var(--link);
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- unify desktop language toggle color with mobile by overriding nav link styles

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/IMHIS/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b2b29cd4ec83269a979bb4241e076a