### PR TITLE
Match burger menu CTA styling with header buttons

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -79,12 +79,16 @@
   }
   .nav-actions--mobile {
     display: flex;
-    flex-direction: column;
+    align-items: center;
     gap: 0.75rem;
   }
   .nav-actions--mobile .btn {
-    width: 100%;
+    display: inline-block;
+    width: auto;
     text-align: center;
+  }
+  .nav-links .btn::after {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- Ensure burger menu CTA buttons use the same styles as header buttons on mobile
- Remove underline effect for CTA buttons inside navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b384ebd88326887e5a36c2f66455