### PR TITLE
Fix accent highlight in about me section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1030,10 +1030,10 @@
       <blockquote class="about-quote">
         <p class="quote-emphasis">
           <span class="lang lang-de">
-            Ich habe IMHIS entwickelt, weil ich an eine Medizin glaube, in der Technologie wieder <span class="accent">dem Menschen </span> dient.
+            Ich habe IMHIS entwickelt, weil ich an eine Medizin glaube, in der Technologie wieder <span class="accent">dem Menschen dient</span>.
           </span>
           <span class="lang lang-en" hidden>
-            I developed IMHIS because I believe in medicine where technology serves <span class="accent">people</span> again.
+            I developed IMHIS because I believe in medicine where technology <span class="accent">serves people</span> again.
           </span>
         </p>
         <p class="quote-emphasis">
@@ -1100,6 +1100,19 @@
     background:linear-gradient(90deg,rgba(37,99,235,.14),rgba(37,99,235,.06));
   }
   .highlight{color:var(--accent);}
+  .about-quote .accent{
+    color:var(--link);
+    font-weight:650;
+    position:relative;
+  }
+  .about-quote .accent::after{
+    content:"";
+    position:absolute;
+    left:0;right:0;bottom:-2px;
+    height:4px;
+    border-radius:4px;
+    background:linear-gradient(90deg,rgba(37,99,235,.14),rgba(37,99,235,.06));
+  }
 
   .about-cite{display:block; margin-top:1.5rem; color:#64748b; font-size:1rem; font-weight:500;}
 


### PR DESCRIPTION
## Summary
- Highlight "dem Menschen dient" in the About IMHIS section and adjust English copy
- Add CSS rules so the accent style displays properly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c802441c83269ff2884faac15efb