### PR TITLE
Fix header CTA buttons wrapping

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -132,6 +132,11 @@ header {
   color: #ffffff;
 }
 
+/* Prevent line breaks in header CTA buttons */
+.nav-actions .btn {
+  white-space: nowrap;
+}
+
 /* Custom styles for navigation and language toggle */
 .nav-toggle {
   border: 2px solid var(--link);
@@ -230,6 +235,7 @@ header {
     display: inline-block;
     width: auto;
     text-align: center;
+    white-space: nowrap;
   }
   .nav-links .btn::after {
     display: none;


### PR DESCRIPTION
## Summary
- prevent line breaks in header CTA buttons
- keep mobile header buttons on a single line

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cf4577348326b14b32fb6ee48830