### PR TITLE
Improve English translations

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -134,7 +134,7 @@
           <li>
             <a href="/index.html#pitch">
               <span class="lang lang-de">Demo ansehen</span>
-              <span class="lang lang-en" hidden>Real impact</span>
+              <span class="lang lang-en" hidden>Watch demo</span>
             </a>
           </li>
           <li>
@@ -160,7 +160,7 @@
             </a>
             <a href="mailto:florianeisold@outlook.de" class="btn primary">
               <span class="lang lang-de">Kostenlos anfragen</span>
-              <span class="lang lang-en" hidden>Request (free)</span>
+              <span class="lang lang-en" hidden>Request for free</span>
             </a>
           </li>
         </ul>
@@ -171,7 +171,7 @@
           </a>
           <a href="mailto:florianeisold@outlook.de" class="btn primary">
             <span class="lang lang-de">Kostenlos anfragen</span>
-            <span class="lang lang-en" hidden>Request (free)</span>
+            <span class="lang lang-en" hidden>Request for free</span>
           </a>
         </div>
       </nav>

--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -112,7 +112,7 @@
           <li>
             <a href="/index.html#pitch">
               <span class="lang lang-de">Demo ansehen</span>
-              <span class="lang lang-en" hidden>Real impact</span>
+              <span class="lang lang-en" hidden>Watch demo</span>
             </a>
           </li>
           <li>
@@ -138,7 +138,7 @@
             </a>
             <a href="mailto:florianeisold@outlook.de" class="btn primary">
               <span class="lang lang-de">Kostenlos anfragen</span>
-              <span class="lang lang-en" hidden>Request (free)</span>
+              <span class="lang lang-en" hidden>Request for free</span>
             </a>
           </li>
         </ul>
@@ -149,7 +149,7 @@
           </a>
           <a href="mailto:florianeisold@outlook.de" class="btn primary">
             <span class="lang lang-de">Kostenlos anfragen</span>
-            <span class="lang lang-en" hidden>Request (free)</span>
+            <span class="lang lang-en" hidden>Request for free</span>
           </a>
         </div>
       </nav>

--- a/impressum.html
+++ b/impressum.html
@@ -114,7 +114,7 @@
           <li>
             <a href="/index.html#pitch">
               <span class="lang lang-de">Demo ansehen</span>
-              <span class="lang lang-en" hidden>Real impact</span>
+              <span class="lang lang-en" hidden>Watch demo</span>
             </a>
           </li>
           <li>
@@ -140,7 +140,7 @@
             </a>
             <a href="mailto:florianeisold@outlook.de" class="btn primary">
               <span class="lang lang-de">Kostenlos anfragen</span>
-              <span class="lang lang-en" hidden>Request (free)</span>
+              <span class="lang lang-en" hidden>Request for free</span>
             </a>
           </li>
         </ul>
@@ -151,7 +151,7 @@
           </a>
           <a href="mailto:florianeisold@outlook.de" class="btn primary">
             <span class="lang lang-de">Kostenlos anfragen</span>
-            <span class="lang lang-en" hidden>Request (free)</span>
+            <span class="lang lang-en" hidden>Request for free</span>
           </a>
         </div>
       </nav>

--- a/index.html
+++ b/index.html
@@ -482,7 +482,7 @@
           Demo ansehen
          </span>
          <span class="lang lang-en" hidden="">
-          Real impact
+          Watch demo
          </span>
         </a>
        </li>
@@ -529,7 +529,7 @@
         Kostenlos anfragen
        </span>
        <span class="lang lang-en" hidden="">
-        Request (free)
+        Request for free
        </span>
       </a>
      </li>
@@ -549,7 +549,7 @@
        Kostenlos anfragen
       </span>
       <span class="lang lang-en" hidden="">
-       Request (free)
+       Request for free
       </span>
      </a>
     </div>
@@ -617,7 +617,7 @@
         </h1>
          <p>
            <span class="lang lang-de">IMHIS macht digitale Wirkung messbar: für <strong>mehr Zeit</strong> für Patienten, <strong>weniger Frust</strong> im Alltag – und Entscheidungen mit <strong>echtem Mehrwert.</strong></span>
-           <span class="lang lang-en" hidden>IMHIS makes digital impact measurable: <strong>more time</strong>for patients, <strong>less frustration</strong> in everyday life &ndash; and decisions with <strong>real added value.</strong></span>
+           <span class="lang lang-en" hidden>IMHIS makes digital impact measurable: <strong>more time</strong> for patients, <strong>less frustration</strong> in everyday life &ndash; and decisions with <strong>real added value.</strong></span>
          </p>
         <ul class="benefits" aria-label="Vorteile">
   <li class="benefit-chip">


### PR DESCRIPTION
## Summary
- Fix navigation translations to use "Watch demo" instead of "Real impact" and adjust CTA to "Request for free" across pages
- Correct spacing in English hero tagline for natural wording

## Testing
- `npx --yes htmlhint datenschutz.html index.html impressum.html florian-eisold.html`


------
https://chatgpt.com/codex/tasks/task_e_68b2dad45f288326b378e897fadf7b1f