### PR TITLE
Refine English phrasing

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -140,7 +140,7 @@
           <li>
             <a href="/index.html#instrument">
               <span class="lang lang-de">Analyseinstrument</span>
-              <span class="lang lang-en" hidden>Assessment Tool</span>
+              <span class="lang lang-en" hidden>Analysis Tool</span>
             </a>
           </li>
           <li>
@@ -156,22 +156,22 @@
           <li class="nav-actions--mobile">
             <a href="/index.html#buch" class="btn secondary">
               <span class="lang lang-de">Buch ansehen</span>
-              <span class="lang lang-en" hidden>View book</span>
+              <span class="lang lang-en" hidden>View the book</span>
             </a>
             <a href="mailto:florianeisold@outlook.de" class="btn primary">
               <span class="lang lang-de">Kostenlos anfragen</span>
-              <span class="lang lang-en" hidden>Request for free</span>
+              <span class="lang lang-en" hidden>Request free access</span>
             </a>
           </li>
         </ul>
         <div class="nav-actions">
           <a href="/index.html#buch" class="btn secondary">
             <span class="lang lang-de">Buch ansehen</span>
-            <span class="lang lang-en" hidden>View book</span>
+            <span class="lang lang-en" hidden>View the book</span>
           </a>
           <a href="mailto:florianeisold@outlook.de" class="btn primary">
             <span class="lang lang-de">Kostenlos anfragen</span>
-            <span class="lang lang-en" hidden>Request for free</span>
+            <span class="lang lang-en" hidden>Request free access</span>
           </a>
         </div>
       </nav>
@@ -717,7 +717,8 @@
             stroke-linejoin="round"
           />
         </svg>
-        Analyse geplant?
+        <span class="lang lang-de">Analyse geplant?</span>
+        <span class="lang lang-en" hidden>Planning an analysis?</span>
       </a>
     </footer>
     <footer class="legal-footer">

--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -118,7 +118,7 @@
           <li>
             <a href="/index.html#instrument">
               <span class="lang lang-de">Analyseinstrument</span>
-              <span class="lang lang-en" hidden>Assessment Tool</span>
+              <span class="lang lang-en" hidden>Analysis Tool</span>
             </a>
           </li>
           <li>
@@ -134,22 +134,22 @@
           <li class="nav-actions--mobile">
             <a href="/index.html#buch" class="btn secondary">
               <span class="lang lang-de">Buch ansehen</span>
-              <span class="lang lang-en" hidden>View book</span>
+              <span class="lang lang-en" hidden>View the book</span>
             </a>
             <a href="mailto:florianeisold@outlook.de" class="btn primary">
               <span class="lang lang-de">Kostenlos anfragen</span>
-              <span class="lang lang-en" hidden>Request for free</span>
+              <span class="lang lang-en" hidden>Request free access</span>
             </a>
           </li>
         </ul>
         <div class="nav-actions">
           <a href="/index.html#buch" class="btn secondary">
             <span class="lang lang-de">Buch ansehen</span>
-            <span class="lang lang-en" hidden>View book</span>
+            <span class="lang lang-en" hidden>View the book</span>
           </a>
           <a href="mailto:florianeisold@outlook.de" class="btn primary">
             <span class="lang lang-de">Kostenlos anfragen</span>
-            <span class="lang lang-en" hidden>Request for free</span>
+            <span class="lang lang-en" hidden>Request free access</span>
           </a>
         </div>
       </nav>
@@ -181,7 +181,8 @@
               target="_blank"
               rel="noopener noreferrer"
             >
-              Jetzt lesen
+              <span class="lang lang-de">Jetzt lesen</span>
+              <span class="lang lang-en" hidden>Read now</span>
             </a>
             <a
               class="btn-secondary about-cta"
@@ -202,7 +203,8 @@
           <rect x="3" y="5" width="18" height="14" rx="2" ry="2" stroke="currentColor" stroke-width="2" stroke-linejoin="round" />
           <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
         </svg>
-        Analyse geplant?
+        <span class="lang lang-de">Analyse geplant?</span>
+        <span class="lang lang-en" hidden>Planning an analysis?</span>
       </a>
     </footer>
     <footer class="legal-footer">

--- a/impressum.html
+++ b/impressum.html
@@ -120,7 +120,7 @@
           <li>
             <a href="/index.html#instrument">
               <span class="lang lang-de">Analyseinstrument</span>
-              <span class="lang lang-en" hidden>Assessment Tool</span>
+              <span class="lang lang-en" hidden>Analysis Tool</span>
             </a>
           </li>
           <li>
@@ -136,22 +136,22 @@
           <li class="nav-actions--mobile">
             <a href="/index.html#buch" class="btn secondary">
               <span class="lang lang-de">Buch ansehen</span>
-              <span class="lang lang-en" hidden>View book</span>
+              <span class="lang lang-en" hidden>View the book</span>
             </a>
             <a href="mailto:florianeisold@outlook.de" class="btn primary">
               <span class="lang lang-de">Kostenlos anfragen</span>
-              <span class="lang lang-en" hidden>Request for free</span>
+              <span class="lang lang-en" hidden>Request free access</span>
             </a>
           </li>
         </ul>
         <div class="nav-actions">
           <a href="/index.html#buch" class="btn secondary">
             <span class="lang lang-de">Buch ansehen</span>
-            <span class="lang lang-en" hidden>View book</span>
+            <span class="lang lang-en" hidden>View the book</span>
           </a>
           <a href="mailto:florianeisold@outlook.de" class="btn primary">
             <span class="lang lang-de">Kostenlos anfragen</span>
-            <span class="lang lang-en" hidden>Request for free</span>
+            <span class="lang lang-en" hidden>Request free access</span>
           </a>
         </div>
       </nav>
@@ -339,7 +339,8 @@
             stroke-linejoin="round"
           />
         </svg>
-        Analyse geplant?
+        <span class="lang lang-de">Analyse geplant?</span>
+        <span class="lang lang-en" hidden>Planning an analysis?</span>
       </a>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -492,7 +492,7 @@
           Analyseinstrument
          </span>
          <span class="lang lang-en" hidden="">
-          Assessment Tool
+          Analysis Tool
          </span>
         </a>
        </li>
@@ -521,7 +521,7 @@
         Buch ansehen
        </span>
        <span class="lang lang-en" hidden="">
-        View book
+        View the book
        </span>
       </a>
       <a class="btn primary" href="mailto:florianeisold@outlook.de">
@@ -529,7 +529,7 @@
         Kostenlos anfragen
        </span>
        <span class="lang lang-en" hidden="">
-        Request for free
+        Request free access
        </span>
       </a>
      </li>
@@ -541,7 +541,7 @@
        Buch ansehen
       </span>
       <span class="lang lang-en" hidden="">
-       View book
+       View the book
       </span>
      </a>
      <a class="btn primary" href="mailto:florianeisold@outlook.de">
@@ -549,7 +549,7 @@
        Kostenlos anfragen
       </span>
       <span class="lang lang-en" hidden="">
-       Request for free
+       Request free access
       </span>
      </a>
     </div>
@@ -800,7 +800,7 @@
         Jetzt alle Effekte mit IMHIS sichtbar machen
        </span>
        <span class="lang lang-en" hidden>
-        Reveal all effects with IMHIS now
+        Reveal the full impact with IMHIS now
        </span>
       </a>
      </div>
@@ -1144,12 +1144,12 @@
   <div class="inner">
       <p class="eyebrow">
         <span class="lang lang-de">Analyseinstrument</span>
-        <span class="lang lang-en" hidden>Assessment Tool</span>
+        <span class="lang lang-en" hidden>Analysis Tool</span>
       </p>
 
       <h2 id="instrument-title">
         <span class="lang lang-de">Ein Analyseinstrument für echten digitalen Fortschritt</span>
-        <span class="lang lang-en" hidden>An assessment tool for real digital progress</span>
+        <span class="lang lang-en" hidden>An analysis tool for real digital progress</span>
       </h2>
 
       <p class="body">
@@ -2078,7 +2078,7 @@
      Analyse geplant?
     </span>
     <span class="lang lang-en" hidden="">
-     Planning an assessment?
+     Planning an analysis?
     </span>
    </a>
   </footer>


### PR DESCRIPTION
## Summary
- polish navigation text with more natural English
- clarify instrument description and hero call to action
- add English text for book link and contact prompts

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2dbfd22ec8326945a860d07f9e450