### PR TITLE
chore: restore mobile language switcher on non-index pages

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -229,7 +229,7 @@ header {
     display: inline-flex;
     margin-right: 1rem;
   }
-  .nav-links .lang-switcher {
+  .nav:has(.lang-switcher--mobile) .nav-links .lang-switcher {
     display: none;
   }
   .nav-actions--mobile {


### PR DESCRIPTION
## Summary
- Hide nav dropdown language switcher only when a separate mobile switcher exists

## Testing
- `npx htmlhint index.html florian-eisold.html datenschutz.html impressum.html`


------
https://chatgpt.com/codex/tasks/task_e_68b2df4dd78883268d201e325625c4fc