### PR TITLE
Fix content-visibility intrinsic size to keep sections responsive

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -25,7 +25,7 @@ a {
 /* Defer rendering of offscreen sections to speed up initial paint */
 .section {
   content-visibility: auto;
-  contain-intrinsic-size: 1000px;
+  contain-intrinsic-size: auto 1000px;
 }
 
 header {


### PR DESCRIPTION
## Summary
- prevent offscreen sections from reserving fixed width by allowing responsive width

## Testing
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e0811e4883268c29734ba525df55