### PR TITLE
Add mail icons to email CTA buttons

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -159,6 +159,10 @@
               <span class="lang lang-en" hidden>View the book</span>
             </a>
             <a href="mailto:florianeisold@outlook.de" class="btn primary">
+              <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+                <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+                <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+              </svg>
               <span class="lang lang-de">Kostenlos anfragen</span>
               <span class="lang lang-en" hidden>Request free access</span>
             </a>
@@ -170,6 +174,10 @@
             <span class="lang lang-en" hidden>View the book</span>
           </a>
           <a href="mailto:florianeisold@outlook.de" class="btn primary">
+            <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+              <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+              <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+            </svg>
             <span class="lang lang-de">Kostenlos anfragen</span>
             <span class="lang lang-en" hidden>Request free access</span>
           </a>

--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -137,6 +137,10 @@
               <span class="lang lang-en" hidden>View the book</span>
             </a>
             <a href="mailto:florianeisold@outlook.de" class="btn primary">
+              <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+                <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+                <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+              </svg>
               <span class="lang lang-de">Kostenlos anfragen</span>
               <span class="lang lang-en" hidden>Request free access</span>
             </a>
@@ -148,6 +152,10 @@
             <span class="lang lang-en" hidden>View the book</span>
           </a>
           <a href="mailto:florianeisold@outlook.de" class="btn primary">
+            <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+              <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+              <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+            </svg>
             <span class="lang lang-de">Kostenlos anfragen</span>
             <span class="lang lang-en" hidden>Request free access</span>
           </a>

--- a/impressum.html
+++ b/impressum.html
@@ -139,6 +139,10 @@
               <span class="lang lang-en" hidden>View the book</span>
             </a>
             <a href="mailto:florianeisold@outlook.de" class="btn primary">
+              <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+                <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+                <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+              </svg>
               <span class="lang lang-de">Kostenlos anfragen</span>
               <span class="lang lang-en" hidden>Request free access</span>
             </a>
@@ -150,6 +154,10 @@
             <span class="lang lang-en" hidden>View the book</span>
           </a>
           <a href="mailto:florianeisold@outlook.de" class="btn primary">
+            <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+              <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+              <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+            </svg>
             <span class="lang lang-de">Kostenlos anfragen</span>
             <span class="lang lang-en" hidden>Request free access</span>
           </a>

--- a/index.html
+++ b/index.html
@@ -529,6 +529,10 @@
        </span>
       </a>
       <a class="btn primary" href="mailto:florianeisold@outlook.de">
+       <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+        <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+        <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+       </svg>
        <span class="lang lang-de">
         Kostenlos anfragen
        </span>
@@ -549,6 +553,10 @@
       </span>
      </a>
      <a class="btn primary" href="mailto:florianeisold@outlook.de">
+      <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+       <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+       <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+      </svg>
       <span class="lang lang-de">
        Kostenlos anfragen
       </span>
@@ -1056,6 +1064,10 @@
       </cite>
 
       <a class="btn-primary about-cta" href="mailto:florianeisold@outlook.de">
+        <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+          <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+          <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+        </svg>
         <span class="lang lang-de">Kontakt aufnehmen</span>
         <span class="lang lang-en" hidden>Get in touch</span>
       </a>

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -116,6 +116,9 @@ header {
   border: none;
   cursor: pointer;
   transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .btn.primary {
@@ -141,6 +144,11 @@ header {
 /* Prevent line breaks in header CTA buttons */
 .nav-actions .btn {
   white-space: nowrap;
+}
+
+.btn svg {
+  width: 20px;
+  height: 20px;
 }
 
 /* Custom styles for navigation and language toggle */
@@ -238,7 +246,8 @@ header {
     gap: 0.75rem;
   }
   .nav-actions--mobile .btn {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     width: auto;
     text-align: center;
     white-space: nowrap;


### PR DESCRIPTION
## Summary
- add envelope icon to all mailto CTA buttons
- align buttons with icons using flex styles

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fc1aea14832694ada5916458a7d8