### PR TITLE
feat: unify language toggle and mobile cta styling

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -114,7 +114,7 @@
             height="74"
           />
         </a>
-        <div class="lang-switcher lang-switcher--mobile" role="group" aria-label="Sprachauswahl">
+        <div class="lang-switcher" role="group" aria-label="Sprachauswahl">
           <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
           <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
         </div>
@@ -148,10 +148,6 @@
               <span class="lang lang-de">News</span>
               <span class="lang lang-en" hidden>News</span>
             </a>
-          </li>
-          <li class="lang-switcher" role="group" aria-label="Sprachauswahl">
-            <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
-            <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
           </li>
           <li class="nav-actions--mobile">
             <a href="/index.html#buch" class="btn secondary">

--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -92,7 +92,7 @@
             height="74"
           />
         </a>
-        <div class="lang-switcher lang-switcher--mobile" role="group" aria-label="Sprachauswahl">
+        <div class="lang-switcher" role="group" aria-label="Sprachauswahl">
           <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
           <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
         </div>
@@ -126,10 +126,6 @@
               <span class="lang lang-de">News</span>
               <span class="lang lang-en" hidden>News</span>
             </a>
-          </li>
-          <li class="lang-switcher" role="group" aria-label="Sprachauswahl">
-            <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
-            <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
           </li>
           <li class="nav-actions--mobile">
             <a href="/index.html#buch" class="btn secondary">

--- a/impressum.html
+++ b/impressum.html
@@ -94,7 +94,7 @@
             height="74"
           />
         </a>
-        <div class="lang-switcher lang-switcher--mobile" role="group" aria-label="Sprachauswahl">
+        <div class="lang-switcher" role="group" aria-label="Sprachauswahl">
           <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
           <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
         </div>
@@ -128,10 +128,6 @@
               <span class="lang lang-de">News</span>
               <span class="lang lang-en" hidden>News</span>
             </a>
-          </li>
-          <li class="lang-switcher" role="group" aria-label="Sprachauswahl">
-            <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
-            <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
           </li>
           <li class="nav-actions--mobile">
             <a href="/index.html#buch" class="btn secondary">

--- a/index.html
+++ b/index.html
@@ -473,7 +473,7 @@
     <a aria-label="IMHIS Startseite" class="logo" href="#top">
      <img alt="IMHIS Logo" data-alt-en="IMHIS logo" decoding="async" fetchpriority="high" height="74" src="assets/Logo_blau.svg" width="398"/>
     </a>
-    <div aria-label="Sprachauswahl" class="lang-switcher lang-switcher--mobile" role="group">
+    <div aria-label="Sprachauswahl" class="lang-switcher" role="group">
      <button aria-label="Deutsch" aria-pressed="true" class="lang-btn" data-lang="de">DE</button>
      <button aria-label="English" aria-pressed="false" class="lang-btn" data-lang="en">EN</button>
     </div>
@@ -513,14 +513,6 @@
         News
        </span>
       </a>
-     </li>
-     <li aria-label="Sprachauswahl" class="lang-switcher" role="group">
-      <button aria-label="Deutsch" aria-pressed="true" class="lang-btn" data-lang="de">
-       DE
-      </button>
-      <button aria-label="English" aria-pressed="false" class="lang-btn" data-lang="en">
-       EN
-      </button>
      </li>
      <!-- Aktionen (nur mobil sichtbar; Desktop separat rechts) -->
      <li class="nav-actions--mobile">

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -212,12 +212,6 @@ header {
   box-shadow: 0 2px 6px rgba(37, 99, 235, 0.35);
 }
 
-.nav-links button.lang-btn[aria-pressed="true"] {
-  background: linear-gradient(135deg, var(--color-primary), #1d4ed8);
-  color: #fff;
-  box-shadow: 0 2px 6px rgba(37, 99, 235, 0.35);
-}
-
 .lang-btn:not([aria-pressed="true"]):hover {
   background: #e0e7ff;
   color: var(--color-primary);
@@ -233,17 +227,9 @@ header {
   font-weight: 700;
 }
 
-.lang-switcher--mobile {
-  display: none;
-}
-
 @media (max-width: 767px) {
-  .lang-switcher--mobile {
-    display: inline-flex;
+  .lang-switcher {
     margin-right: 1rem;
-  }
-  .nav:has(.lang-switcher--mobile) .nav-links .lang-switcher {
-    display: none;
   }
   .nav-actions--mobile {
     display: flex;
@@ -262,6 +248,15 @@ header {
   }
   .nav-links .btn::after {
     display: none;
+  }
+  .nav-actions--mobile .btn.primary {
+    background: var(--color-primary);
+    color: #ffffff;
+  }
+  .nav-actions--mobile .btn.secondary {
+    background: transparent;
+    color: var(--color-primary);
+    border: 2px solid var(--color-primary);
   }
 }
 


### PR DESCRIPTION
## Summary
- reuse mobile language switcher design on desktop and remove duplicate desktop toggle
- ensure mobile navigation CTAs use same primary/secondary colors as header buttons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b32ad6aaac83269dd4cdffa5f54a5e