### PR TITLE
Add default subject for email contact links

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -154,7 +154,7 @@
               <span class="lang lang-de">Buch ansehen</span>
               <span class="lang lang-en" hidden>View the book</span>
             </a>
-            <a href="mailto:florianeisold@outlook.de" class="btn primary">
+            <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS" class="btn primary">
               <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
                 <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
                 <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
@@ -169,7 +169,7 @@
             <span class="lang lang-de">Buch ansehen</span>
             <span class="lang lang-en" hidden>View the book</span>
           </a>
-          <a href="mailto:florianeisold@outlook.de" class="btn primary">
+          <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS" class="btn primary">
             <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
               <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
               <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
@@ -321,7 +321,7 @@
           Am Rheinquartier 24<br />
           56112 Lahnstein<br />
           E-Mail:
-          <a href="mailto:florianeisold@outlook.de"
+          <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS"
             >florianeisold@outlook.de</a
           >
         </p>
@@ -693,7 +693,7 @@
     </main>
 
     <footer id="kontakt" class="contact-footer">
-      <a href="mailto:florianeisold@outlook.de" class="cta">
+      <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS" class="cta">
         <svg
           width="20"
           height="20"
@@ -733,7 +733,7 @@
       <p class="copyright">
         © 2025 Dr. Florian Eisold. Inhalte urheberrechtlich
         geschützt. Für Kooperationen oder Nutzungsanfragen:
-        <a href="mailto:florianeisold@outlook.de">florianeisold@outlook.de</a>
+        <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">florianeisold@outlook.de</a>
       </p>
     </footer>
 

--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -132,7 +132,7 @@
               <span class="lang lang-de">Buch ansehen</span>
               <span class="lang lang-en" hidden>View the book</span>
             </a>
-            <a href="mailto:florianeisold@outlook.de" class="btn primary">
+            <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS" class="btn primary">
               <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
                 <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
                 <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
@@ -147,7 +147,7 @@
             <span class="lang lang-de">Buch ansehen</span>
             <span class="lang lang-en" hidden>View the book</span>
           </a>
-          <a href="mailto:florianeisold@outlook.de" class="btn primary">
+          <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS" class="btn primary">
             <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
               <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
               <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
@@ -202,7 +202,7 @@
     </main>
 
     <footer id="kontakt" class="contact-footer">
-      <a href="mailto:florianeisold@outlook.de" class="cta">
+      <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS" class="cta">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <rect x="3" y="5" width="18" height="14" rx="2" ry="2" stroke="currentColor" stroke-width="2" stroke-linejoin="round" />
           <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
@@ -218,7 +218,7 @@
       </div>
       <p class="copyright">
         © 2025 Dr. Florian Eisold. Inhalte urheberrechtlich geschützt. Für Kooperationen oder Nutzungsanfragen:
-        <a href="mailto:florianeisold@outlook.de">florianeisold@outlook.de</a>
+        <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">florianeisold@outlook.de</a>
       </p>
     </footer>
 

--- a/impressum.html
+++ b/impressum.html
@@ -134,7 +134,7 @@
               <span class="lang lang-de">Buch ansehen</span>
               <span class="lang lang-en" hidden>View the book</span>
             </a>
-            <a href="mailto:florianeisold@outlook.de" class="btn primary">
+            <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS" class="btn primary">
               <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
                 <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
                 <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
@@ -149,7 +149,7 @@
             <span class="lang lang-de">Buch ansehen</span>
             <span class="lang lang-en" hidden>View the book</span>
           </a>
-          <a href="mailto:florianeisold@outlook.de" class="btn primary">
+          <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS" class="btn primary">
             <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
               <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
               <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
@@ -179,7 +179,7 @@
         <p>
           Dr. Florian Eisold<br />
           E-Mail:
-          <a href="mailto:florianeisold@outlook.de"
+          <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS"
             >florianeisold@outlook.de</a
           >
         </p>
@@ -315,7 +315,7 @@
     </main>
 
     <footer id="kontakt" class="contact-footer">
-      <a href="mailto:florianeisold@outlook.de" class="cta">
+      <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS" class="cta">
         <svg
           width="20"
           height="20"
@@ -356,7 +356,7 @@
       <p class="copyright">
         © 2025 Dr. Florian Eisold. Inhalte urheberrechtlich
         geschützt. Für Kooperationen oder Nutzungsanfragen:
-        <a href="mailto:florianeisold@outlook.de">florianeisold@outlook.de</a>
+        <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">florianeisold@outlook.de</a>
       </p>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -524,7 +524,7 @@
         View the book
        </span>
       </a>
-      <a class="btn primary" href="mailto:florianeisold@outlook.de">
+      <a class="btn primary" href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">
        <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
         <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
         <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
@@ -548,7 +548,7 @@
        View the book
       </span>
      </a>
-     <a class="btn primary" href="mailto:florianeisold@outlook.de">
+     <a class="btn primary" href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">
       <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
        <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
        <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
@@ -1059,7 +1059,7 @@
         <span class="lang lang-en" hidden><a href="florian-eisold.html">Dr. Florian Eisold, M.D., B.Sc., LL.M.</a> – physician and developer of IMHIS</span>
       </cite>
 
-      <a class="btn-primary about-cta" href="mailto:florianeisold@outlook.de">
+      <a class="btn-primary about-cta" href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">
         <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
           <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
           <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
@@ -2090,7 +2090,7 @@
    </section>
   </main>
   <footer class="contact-footer" id="kontakt">
-   <a class="cta" href="mailto:florianeisold@outlook.de">
+   <a class="cta" href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">
     <svg aria-hidden="true" fill="none" height="20" viewbox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
      <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5">
      </rect>
@@ -2139,7 +2139,7 @@
    <p class="copyright">
     © 2025 Dr. Florian Eisold. Inhalte urheberrechtlich
         geschützt. Für Kooperationen oder Nutzungsanfragen:
-    <a href="mailto:florianeisold@outlook.de">
+    <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">
      florianeisold@outlook.de
     </a>
    </p>


### PR DESCRIPTION
## Summary
- avoid spam by adding a default `Kontaktaufnahme IMHIS` subject to all email contact links

## Testing
- `npx -y htmlhint index.html florian-eisold.html datenschutz.html impressum.html`

------
https://chatgpt.com/codex/tasks/task_e_68b32c4e6d108326807b32d77ff7f01f