### PR TITLE
fix: style mobile CTA buttons in burger menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,6 +184,15 @@
           display: block;
           font-size: 1.1rem;
         }
+
+        .nav-links .btn {
+          display: inline-flex;
+          width: 100%;
+        }
+
+        .nav-links .btn::after {
+          display: none;
+        }
       }
 
       .cta-buttons {

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -106,6 +106,15 @@ header {
     display: block;
     font-size: 1.1rem;
   }
+
+  .nav-links .btn {
+    display: inline-flex;
+    width: 100%;
+  }
+
+  .nav-links .btn::after {
+    display: none;
+  }
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- ensure mobile navigation CTA buttons share desktop design
- remove mobile nav link pseudo-element and restore flex display

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b32ecb4f548326b24f58484a944748