### PR TITLE
Fix nav anchor offset for section links

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,18 +76,22 @@
       }
 
       /* Grundaufbau */
-      body {
-        margin: 0;
-        font-family: "Inter", sans-serif;
-        color: var(--color-text);
-        background: var(--color-bg);
-        line-height: 1.6;
-      }
+        body {
+          margin: 0;
+          font-family: "Inter", sans-serif;
+          color: var(--color-text);
+          background: var(--color-bg);
+          line-height: 1.6;
+        }
 
-      a {
-        color: inherit;
-        text-decoration: none;
-      }
+        html {
+          scroll-padding-top: var(--nav-height);
+        }
+
+        a {
+          color: inherit;
+          text-decoration: none;
+        }
 
       /* Header und Navigation */
       header {

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -17,6 +17,10 @@ body {
   line-height: 1.6;
 }
 
+html {
+  scroll-padding-top: var(--nav-height);
+}
+
 a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
## Summary
- ensure anchor links scroll sections to the very top by compensating for sticky nav height
- apply scroll-padding-top via CSS for consistent behavior across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f576f0d8832698b636a80bf47e90