### PR TITLE
Refine about section quote and CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -598,20 +598,16 @@
 
       <blockquote class="about-quote">
         <p class="quote-emphasis">
-          <span class="lang lang-de">
-            Ich habe IMHIS entwickelt, weil ich an eine Medizin glaube, in der Technologie wieder <span class="accent">dem Menschen dient</span>.
-          </span>
-          <span class="lang lang-en" hidden>
-            I developed IMHIS because I believe in medicine where technology <span class="accent">serves people</span> again.
-          </span>
+          <span class="lang lang-de">Ich habe IMHIS entwickelt, weil ich an eine Medizin glaube, in der Technologie wieder <span class="accent">dem Menschen dient</span>.</span>
+          <span class="lang lang-en" hidden>I developed IMHIS because I believe in medicine where technology <span class="accent">serves people</span> again.</span>
         </p>
         <p class="quote-emphasis">
-          <span class="lang lang-de">Nicht das System braucht unsere Zeit<br /><strong class="gradient-underline">– die Patienten tun es.</strong></span>
-          <span class="lang lang-en" hidden>It's not the system that needs our time<br /><strong class="gradient-underline">– the patients do.</strong></span>
+          <span class="lang lang-de">Nicht das System braucht unsere Zeit – <span class="accent">die Patienten tun es.</span></span>
+          <span class="lang lang-en" hidden>It's not the system that needs our time – <span class="accent">the patients do.</span></span>
         </p>
         <p>
-          <span class="lang lang-de">Was wir brauchen, ist eine Digitalisierung, die <span class="highlight">spürbar entlastet</span> und <span class="highlight">messbar wirkt</span>.</span>
-          <span class="lang lang-en" hidden>We need digitalisation that <span class="highlight">provides tangible relief</span> and <span class="highlight">has measurable impact</span>.</span>
+          <span class="lang lang-de">Was wir brauchen, ist eine Digitalisierung, die <span class="accent">spürbar entlastet</span> und <span class="accent">messbar wirkt</span>.</span>
+          <span class="lang lang-en" hidden>We need digitalisation that <span class="accent">provides tangible relief</span> and <span class="accent">has measurable impact</span>.</span>
         </p>
       </blockquote>
 

--- a/style.css
+++ b/style.css
@@ -484,60 +484,30 @@
 
 
   .about-quote{
-    margin:0; position:relative; /* für das Anführungszeichen */
-    font-weight:400; font-size:clamp(1.4rem,2.5vw,1.8rem); line-height:1.6; color:#1e293b;
+    margin:0;position:relative;/* subtile Anführungszeichen */
+    font-weight:400;font-size:clamp(1.1rem,2.2vw,1.5rem);line-height:1.7;
+    max-width:60ch;color:#1e293b;
   }
   .about-quote::before{
-    content:"“"; position:absolute; font-size:6rem; line-height:1; font-weight:900;
-    color:rgba(37,99,235,.12); left:-1rem; top:-2rem;
+    content:"“";position:absolute;font-size:4rem;line-height:1;font-weight:700;
+    color:rgba(37,99,235,.1);left:-.5rem;top:-1rem;
   }
-  .about-quote p{margin:.6rem 0;}
-  .about-quote p:first-of-type{font-weight:600;}
-  .about-quote p + p{margin-top:1.2rem;}
-  .gradient-underline{position:relative;}
-  .gradient-underline::after{
-    content:"";position:absolute;left:0;right:0;bottom:-2px;height:4px;border-radius:4px;
-    background:linear-gradient(90deg,rgba(37,99,235,.14),rgba(37,99,235,.06));
-  }
-  .highlight{color:var(--accent);}
-  .about-quote .accent{
-    color:var(--link);
-    font-weight:650;
-    position:relative;
-  }
-  .about-quote .accent::after{
-    content:"";
-    position:absolute;
-    left:0;right:0;bottom:-2px;
-    height:4px;
-    border-radius:4px;
-    background:linear-gradient(90deg,rgba(37,99,235,.14),rgba(37,99,235,.06));
-  }
+  .about-quote p{margin:0 0 1rem;}
+  .about-quote p:last-of-type{margin-bottom:0;}
+  .about-quote .quote-emphasis{font-weight:600;}
+  .about-quote .accent{color:var(--link);font-weight:600;}
 
   .about-cite{display:block; margin-top:1.5rem; color:#64748b; font-size:1rem; font-weight:500;}
 
   .about-cta{
-    display:inline-flex;
-    align-items:center;
-    justify-content:center;
-    gap:.6rem;
-    margin:2rem auto 0;
-    padding:1rem 1.5rem;
-    border-radius:14px;
-    font-weight:600;
-    font-size:1.05rem;
-    text-decoration:none;
-    text-align:center;
-    color:#fff;
-    background:linear-gradient(135deg,var(--accent),#1d4ed8);
-    box-shadow:0 10px 28px rgba(37,99,235,.25);
-    transition:all .25s ease;
+    display:flex;align-items:center;justify-content:center;flex-direction:row;
+    gap:.6rem;margin:2rem auto 0;padding:1rem 1.5rem;border-radius:14px;
+    font-weight:600;font-size:1.05rem;text-decoration:none;white-space:nowrap;
+    color:#fff;background:linear-gradient(135deg,var(--accent),#1d4ed8);
+    box-shadow:0 10px 28px rgba(37,99,235,.25);transition:all .25s ease;
   }
   .about-cta svg{
-    width:20px;
-    height:20px;
-    flex-shrink:0;
-    display:block;
+    width:20px;height:20px;flex-shrink:0;
   }
   .about-cta:hover{ transform:translateY(-2px); box-shadow:0 14px 32px rgba(37,99,235,.35); }
 

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -237,8 +237,8 @@ header {
 }
 
 .about-quote .quote-emphasis {
-  font-size: 1.6rem;
-  font-weight: 700;
+  font-size: clamp(1.3rem, 3vw, 1.6rem);
+  font-weight: 600;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
## Summary
- streamline quote markup for calmer presentation
- align CTA button icon and text on one line
- tune typography for emphasis in about section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b40f8aa1c08326aef57b09b4e011e6