### PR TITLE
Refine pitch CTA and metric emphasis

### DIFF
--- a/style.css
+++ b/style.css
@@ -459,7 +459,7 @@
     color:#1e293b;
   }
       .analysis-header{display:flex;align-items:flex-start;gap:1rem;margin-top:2rem;margin-bottom:1rem;flex-wrap:wrap;}
-      .analysis-header .pitch-cta{margin-top:0;}
+      .analysis-header .pitch-cta{margin-top:0;width:100%;max-width:22rem;white-space:normal;text-align:center;font-size:clamp(1rem,3.5vw,1.125rem);line-height:1.3;}
       @media (max-width:700px){.analysis-header{flex-direction:column;align-items:flex-start;}.analysis-header .pitch-cta{margin-top:1rem;}}
   .about-me-section{
     --accent:#2563eb; --ink:#0b1220;
@@ -707,7 +707,8 @@
 .counter-wrapper{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:2rem;margin:2rem 0 3rem;}
 .counter-card{position:relative;background:linear-gradient(to bottom right,rgba(255,255,255,0.9),rgba(245,250,255,0.9));backdrop-filter:blur(12px);padding:1.75rem;border-radius:1rem;box-shadow:0 10px 24px rgba(0,0,0,0.07);text-align:center;}
 .icon-wrapper{width:48px;height:48px;margin:0 auto 0.75rem;display:flex;align-items:center;justify-content:center;background:rgba(37,88,235,0.12);border-radius:50%;}
-.counter-number{font-size:2.8rem;font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:center;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;}
+.counter-number{font-size:clamp(2.8rem,6vw,4rem);font-weight:700;color:var(--accent);display:flex;justify-content:center;align-items:center;gap:0.25rem;filter:blur(5px) opacity(0.5);transition:filter 0.8s ease-out, opacity 0.8s ease-out;}
+.counter-number .number{background:linear-gradient(90deg,var(--accent),#1d4ed8);-webkit-background-clip:text;-webkit-text-fill-color:transparent;}
 .counter-number .prefix{font-size:1.8rem;line-height:1;}
 .counter-number .unit{font-size:1.4rem;}
 .counter-label{margin-top:0.5rem;font-size:0.95rem;color:var(--text);}


### PR DESCRIPTION
## Summary
- Make pitch section CTA responsive by constraining width and allowing text wrapping
- Increase prominence of pitch metrics with larger, gradient-highlighted numbers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b411a441808326b413bb68cda08e3b