### PR TITLE
Center pitch CTA with example text

### DIFF
--- a/style.css
+++ b/style.css
@@ -458,9 +458,9 @@
     line-height:1.55;
     color:#1e293b;
   }
-      .analysis-header{display:flex;align-items:flex-start;gap:1rem;margin-top:2rem;margin-bottom:1rem;flex-wrap:wrap;}
-      .analysis-header .pitch-cta{margin-top:0;width:100%;max-width:22rem;white-space:normal;text-align:center;font-size:clamp(1rem,3.5vw,1.125rem);line-height:1.3;}
-      @media (max-width:700px){.analysis-header{flex-direction:column;align-items:flex-start;}.analysis-header .pitch-cta{margin-top:1rem;}}
+      .analysis-header{display:flex;align-items:center;gap:1rem;margin-top:2rem;margin-bottom:1rem;flex-wrap:wrap;}
+      .analysis-header .pitch-cta{margin-top:0;max-width:22rem;white-space:normal;text-align:center;font-size:clamp(1rem,3.5vw,1.125rem);line-height:1.3;}
+      @media (max-width:700px){.analysis-header{flex-direction:column;align-items:flex-start;}.analysis-header .pitch-cta{margin-top:1rem;width:100%;}}
   .about-me-section{
     --accent:#2563eb; --ink:#0b1220;
     max-width:1200px; margin:3rem auto; padding:4rem 1rem;


### PR DESCRIPTION
## Summary
- Align pitch example badge and CTA button vertically using flexbox
- Limit CTA width behavior for desktop and mobile to keep button next to example text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b416dc53508326ace781d9d8b03b9e