### PR TITLE
Apply pitch-cta styling to primary buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -160,14 +160,17 @@
       }
 
       .btn.primary {
-        background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+        padding: 1rem 1.5rem;
+        border-radius: 14px;
+        background: linear-gradient(135deg, var(--color-primary), #1d4ed8);
         color: #ffffff;
-        box-shadow: 0 4px 12px rgba(37, 99, 235, 0.4);
+        box-shadow: 0 10px 28px rgba(37, 99, 235, 0.25);
+        transition: all 0.25s ease;
       }
 
       .btn.primary:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 6px 16px rgba(37, 99, 235, 0.45);
+        transform: translateY(-2px);
+        box-shadow: 0 14px 32px rgba(37, 99, 235, 0.35);
       }
 
       .btn.secondary {
@@ -734,14 +737,17 @@
   }
 
   .nav-actions--mobile .btn.primary {
-    background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+    padding: 1rem 1.5rem;
+    border-radius: 14px;
+    background: linear-gradient(135deg, var(--color-primary), #1d4ed8);
     color: #fff;
-    box-shadow: 0 6px 14px rgba(37, 99, 235, 0.4);
+    box-shadow: 0 10px 28px rgba(37, 99, 235, 0.25);
+    transition: all 0.25s ease;
   }
 
   .nav-actions--mobile .btn.primary:hover {
     transform: translateY(-2px);
-    box-shadow: 0 10px 20px rgba(37, 99, 235, 0.45);
+    box-shadow: 0 14px 32px rgba(37, 99, 235, 0.35);
   }
 
   .nav-actions--mobile .btn.secondary {

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -136,15 +136,17 @@ header {
 }
 
 .btn.primary {
-  background: linear-gradient(135deg, var(--color-primary), #1e40af);
+  padding: 1rem 1.5rem;
+  border-radius: 14px;
+  background: linear-gradient(135deg, var(--color-primary), #1d4ed8);
   color: #ffffff;
-  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.35);
+  box-shadow: 0 10px 28px rgba(37, 99, 235, 0.25);
+  transition: all 0.25s ease;
 }
 
 .btn.primary:hover {
-  background: linear-gradient(135deg, #1e4fd1, #1e40af);
-  box-shadow: 0 6px 14px rgba(32, 51, 97, 0.3);
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 32px rgba(37, 99, 235, 0.35);
 }
 
 .btn.secondary {
@@ -275,9 +277,16 @@ header {
     display: none;
   }
   .nav-actions--mobile .btn.primary {
-    background: linear-gradient(135deg, var(--link), #1d4ed8);
+    padding: 1rem 1.5rem;
+    border-radius: 14px;
+    background: linear-gradient(135deg, var(--color-primary), #1d4ed8);
     color: #ffffff;
-    box-shadow: 0 4px 10px rgba(37, 99, 235, 0.3);
+    box-shadow: 0 10px 28px rgba(37, 99, 235, 0.25);
+    transition: all 0.25s ease;
+  }
+  .nav-actions--mobile .btn.primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 32px rgba(37, 99, 235, 0.35);
   }
   .nav-actions--mobile .btn.secondary {
     background: #ffffff;


### PR DESCRIPTION
## Summary
- restyle `.btn.primary` with pitch-cta gradient, padding and hover effects
- align mobile navigation primary buttons with the pitch-cta look

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b41a6e8f908326803e8de64c81cc06