### PR TITLE
Standardize CTA button shape

### DIFF
--- a/style.css
+++ b/style.css
@@ -147,7 +147,7 @@
 
       .btn {
         padding: 0.65rem 1.25rem;
-        border-radius: 999px;
+        border-radius: 14px;
         font-weight: 600;
         font-size: 1rem;
         border: none;
@@ -161,7 +161,6 @@
 
       .btn.primary {
         padding: 1rem 1.5rem;
-        border-radius: 14px;
         background: linear-gradient(135deg, var(--color-primary), #1d4ed8);
         color: #ffffff;
         box-shadow: 0 10px 28px rgba(37, 99, 235, 0.25);
@@ -738,7 +737,6 @@
 
   .nav-actions--mobile .btn.primary {
     padding: 1rem 1.5rem;
-    border-radius: 14px;
     background: linear-gradient(135deg, var(--color-primary), #1d4ed8);
     color: #fff;
     box-shadow: 0 10px 28px rgba(37, 99, 235, 0.25);

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -123,7 +123,7 @@ header {
 
 .btn {
   padding: 0.65rem 1.25rem;
-  border-radius: 999px;
+  border-radius: 14px;
   font-weight: 600;
   font-size: 1rem;
   border: none;
@@ -137,7 +137,6 @@ header {
 
 .btn.primary {
   padding: 1rem 1.5rem;
-  border-radius: 14px;
   background: linear-gradient(135deg, var(--color-primary), #1d4ed8);
   color: #ffffff;
   box-shadow: 0 10px 28px rgba(37, 99, 235, 0.25);
@@ -278,7 +277,6 @@ header {
   }
   .nav-actions--mobile .btn.primary {
     padding: 1rem 1.5rem;
-    border-radius: 14px;
     background: linear-gradient(135deg, var(--color-primary), #1d4ed8);
     color: #ffffff;
     box-shadow: 0 10px 28px rgba(37, 99, 235, 0.25);


### PR DESCRIPTION
## Summary
- Harmonize CTA buttons by setting a consistent 14px border radius across primary and secondary styles
- Remove redundant border-radius overrides in mobile navigation to keep button appearance uniform

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b41c74025483268dadbc7ff60a4e8f