### PR TITLE
Align header CTA buttons and add book icon

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -151,6 +151,9 @@
           </li>
           <li class="nav-actions--mobile">
             <a href="/index.html#buch" class="btn secondary">
+              <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+              </svg>
               <span class="lang lang-de">Buch ansehen</span>
               <span class="lang lang-en" hidden>View the book</span>
             </a>
@@ -166,6 +169,9 @@
         </ul>
         <div class="nav-actions">
           <a href="/index.html#buch" class="btn secondary">
+            <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+            </svg>
             <span class="lang lang-de">Buch ansehen</span>
             <span class="lang lang-en" hidden>View the book</span>
           </a>

--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -129,6 +129,9 @@
           </li>
           <li class="nav-actions--mobile">
             <a href="/index.html#buch" class="btn secondary">
+              <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+              </svg>
               <span class="lang lang-de">Buch ansehen</span>
               <span class="lang lang-en" hidden>View the book</span>
             </a>
@@ -144,6 +147,9 @@
         </ul>
         <div class="nav-actions">
           <a href="/index.html#buch" class="btn secondary">
+            <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+            </svg>
             <span class="lang lang-de">Buch ansehen</span>
             <span class="lang lang-en" hidden>View the book</span>
           </a>

--- a/impressum.html
+++ b/impressum.html
@@ -131,6 +131,9 @@
           </li>
           <li class="nav-actions--mobile">
             <a href="/index.html#buch" class="btn secondary">
+              <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+              </svg>
               <span class="lang lang-de">Buch ansehen</span>
               <span class="lang lang-en" hidden>View the book</span>
             </a>
@@ -146,6 +149,9 @@
         </ul>
         <div class="nav-actions">
           <a href="/index.html#buch" class="btn secondary">
+            <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+            </svg>
             <span class="lang lang-de">Buch ansehen</span>
             <span class="lang lang-en" hidden>View the book</span>
           </a>

--- a/index.html
+++ b/index.html
@@ -130,6 +130,9 @@
      <!-- Aktionen (nur mobil sichtbar; Desktop separat rechts) -->
      <li class="nav-actions--mobile">
       <a class="btn secondary" href="#buch">
+       <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+       </svg>
        <span class="lang lang-de">
         Buch ansehen
        </span>
@@ -154,6 +157,9 @@
     <!-- Aktionen rechts (nur Desktop) -->
     <div class="nav-actions">
      <a class="btn secondary" href="#buch">
+      <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+       <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+      </svg>
       <span class="lang lang-de">
        Buch ansehen
       </span>

--- a/style.css
+++ b/style.css
@@ -150,7 +150,8 @@
         border-radius: 14px;
         font-weight: 600;
         font-size: 1rem;
-        border: none;
+        border: 2px solid transparent;
+        box-sizing: border-box;
         cursor: pointer;
         transition: all 0.2s ease;
         display: inline-flex;

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -123,11 +123,12 @@ header {
 }
 
 .btn {
-  padding: 0.65rem 1.25rem;
+  padding: 1rem 1.5rem;
   border-radius: 14px !important;
   font-weight: 600;
   font-size: 1rem;
-  border: none;
+  border: 2px solid transparent;
+  box-sizing: border-box;
   cursor: pointer;
   transition: all 0.2s ease;
   display: inline-flex;


### PR DESCRIPTION
## Summary
- Make primary and secondary buttons share the same dimensions by using equal padding and a transparent base border
- Add a matching book icon to "Buch ansehen" header links on all pages

## Testing
- `npx -y htmlhint index.html datenschutz.html florian-eisold.html impressum.html`

------
https://chatgpt.com/codex/tasks/task_e_68b431daab648326aafc7081dc4d4ef7