### PR TITLE
Equalize CTA button heights and center email icon

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -173,10 +173,24 @@ header {
   height: 20px;
 }
 
+/* Ensure CTA buttons in the book section share equal height */
+.order-buttons {
+  align-items: stretch;
+}
+
 .about-cta {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
+  white-space: nowrap;
+}
+
+.about-cta svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  display: block;
 }
 
 .about-cta span {


### PR DESCRIPTION
## Summary
- Stretch book section order buttons so "Weitere Händler anzeigen" aligns with "Jetzt lesen"
- Center email icon alongside text in about section CTA to avoid line breaks

## Testing
- `npx --yes htmlhint index.html florian-eisold.html`


------
https://chatgpt.com/codex/tasks/task_e_68b4346e648083269d0ad1a58ece1f43