### PR TITLE
Align book section CTA button heights

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -174,7 +174,7 @@ header {
 }
 
 /* Ensure CTA buttons in the book section share equal height */
-.order-buttons {
+.book-section .order-buttons {
   align-items: stretch;
 }
 


### PR DESCRIPTION
## Summary
- Ensure book section call-to-action buttons share equal height by stretching flex items

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b43a145b78832697db95ac4d276aad