### PR TITLE
Center about‑me CTA button contents

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -179,10 +179,11 @@ header {
 }
 
 .about-cta {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
+  margin: 1.2rem auto 0;
   white-space: nowrap;
 }
 
@@ -190,7 +191,6 @@ header {
   width: 20px;
   height: 20px;
   flex-shrink: 0;
-  display: block;
 }
 
 .about-cta span {


### PR DESCRIPTION
## Summary
- Center the about-me CTA button so icon and text sit side-by-side and the button aligns under its text

## Testing
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b43c22b1bc8326b00f77b58c746e09