### PR TITLE
Fix CTA icon alignment in about section

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -178,7 +178,9 @@ header {
   align-items: stretch;
 }
 
-.about-cta {
+
+.about-cta,
+.about-content .about-cta {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -191,6 +193,7 @@ header {
   width: 20px;
   height: 20px;
   flex-shrink: 0;
+  display: inline-block;
 }
 
 .about-cta span {


### PR DESCRIPTION
## Summary
- Ensure `about-cta` buttons display icon and text in a single centered row
- Override conflicting selector from main styles
- Make envelope SVG inline-block to keep layout stable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b440ac4828832685fc5e681bc1bd7a