### PR TITLE
Reduce about-cta button width for centered icon and text

### DIFF
--- a/style.css
+++ b/style.css
@@ -504,6 +504,7 @@
   .about-cta{
     display:flex;align-items:center;justify-content:center;flex-direction:row;
     gap:.6rem;margin:2rem auto 0;padding:1rem 1.5rem;border-radius:14px;
+    width:fit-content;
     font-weight:600;font-size:1.05rem;text-decoration:none;white-space:nowrap;
     color:#fff;background:linear-gradient(135deg,var(--accent),#1d4ed8);
     box-shadow:0 10px 28px rgba(37,99,235,.25);transition:all .25s ease;

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -186,6 +186,7 @@ header {
   justify-content: center;
   gap: 0.5rem;
   margin: 1.2rem auto 0;
+  width: fit-content;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- Constrain about-cta buttons to `fit-content` width so icon and label align in a single centered row

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4453697d88326aa32100b9a3fc4a0