### PR TITLE
Refine pitch CTA with Black Box reveal design

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,7 +370,7 @@
         </strong>
        </span>
       </div>
-      <a class="about-cta pitch-cta" href="#pitch" id="reveal-effects">
+       <a class="about-cta pitch-cta black-box-cta" href="#pitch" id="reveal-effects">
        <span class="lang lang-de">
         Jetzt alle Effekte mit IMHIS sichtbar machen
        </span>
@@ -1621,11 +1621,12 @@
   const revealBtn = document.getElementById('reveal-effects');
   if (revealBtn) {
     let revealed = false;
-    revealBtn.addEventListener('click', function (e) {
-      e.preventDefault();
-      if (revealed) return;
-      revealed = true;
-      const allCounters = Array.from(counters);
+      revealBtn.addEventListener('click', function (e) {
+        e.preventDefault();
+        if (revealed) return;
+        revealed = true;
+        revealBtn.classList.add('revealed');
+        const allCounters = Array.from(counters);
       allCounters.forEach((counter, index) => {
         if (index === 0) return; // Erste Karte ist schon animiert
         setTimeout(() => {

--- a/style.css
+++ b/style.css
@@ -518,6 +518,33 @@
     .about-content .about-cta{ margin:2rem 0 0; }
   }
 
+  /* Black Box styled CTA for revealing hidden effects */
+  .black-box-cta{
+    background:linear-gradient(180deg,#0b111f,#0a1326);
+    border:1px solid rgba(255,255,255,.08);
+    box-shadow:inset 0 1px 0 rgba(255,255,255,.06),0 6px 14px rgba(2,6,23,.18);
+    color:#fff;
+    position:relative;
+    overflow:hidden;
+    transition:background .3s ease,color .3s ease,box-shadow .3s ease;
+  }
+  .black-box-cta::after{
+    content:"";
+    position:absolute;
+    top:0;left:-100%;
+    width:100%;height:100%;
+    background:linear-gradient(120deg,transparent,rgba(255,255,255,.2),transparent);
+    transition:left .6s ease;
+  }
+  .black-box-cta:hover::after{left:100%;}
+  .black-box-cta:hover,
+  .black-box-cta.revealed{
+    background:transparent;
+    color:#1e293b;
+    border-color:transparent;
+    box-shadow:none;
+  }
+
   @media (max-width:860px){
     .about-wrap{ grid-template-columns:1fr; text-align:center; }
     .about-img{ margin:0 auto 1.5rem; }


### PR DESCRIPTION
## Summary
- Align pitch CTA button with Black Box styling, including gradient, border, and shimmer reveal effect.
- Highlight card reveal action via JS by toggling a `revealed` state on click.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4492a5df88326a32273509252bc2d