### PR TITLE
Align pitch CTA next to analysis badge

### DIFF
--- a/style.css
+++ b/style.css
@@ -460,8 +460,8 @@
     line-height:1.55;
     color:#1e293b;
   }
-      .analysis-header{display:flex;align-items:stretch;gap:1rem;margin-top:2rem;margin-bottom:1rem;flex-wrap:wrap;}
-      .analysis-header .pitch-cta{margin-top:0;max-width:22rem;white-space:normal;text-align:center;font-size:clamp(1rem,3.5vw,1.125rem);line-height:1.3;display:flex;align-items:center;}
+      .analysis-header{display:flex;align-items:flex-start;gap:1rem;margin-top:2rem;margin-bottom:1rem;flex-wrap:wrap;}
+      .analysis-header .pitch-cta{margin-top:0;max-width:22rem;white-space:normal;text-align:left;font-size:clamp(1rem,3.5vw,1.125rem);line-height:1.3;display:flex;align-items:center;justify-content:flex-start;}
       @media (max-width:700px){.analysis-header{flex-direction:column;align-items:flex-start;}.analysis-header .pitch-cta{margin-top:1rem;width:100%;}}
   .about-me-section{
     --accent:#2563eb; --ink:#0b1220;


### PR DESCRIPTION
## Summary
- Left-align pitch CTA beside analysis badge and stack beneath on mobile.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b44ac27a6883268f69acb673063ad8