### PR TITLE
Align pitch badge height and center CTA text

### DIFF
--- a/style.css
+++ b/style.css
@@ -460,8 +460,8 @@
     line-height:1.55;
     color:#1e293b;
   }
-      .analysis-header{display:flex;align-items:center;gap:1rem;margin-top:2rem;margin-bottom:1rem;flex-wrap:wrap;}
-      .analysis-header .pitch-cta{margin:0;max-width:22rem;white-space:normal;text-align:left;font-size:clamp(1rem,3.5vw,1.125rem);line-height:1.3;display:flex;align-items:center;justify-content:flex-start;}
+      .analysis-header{display:flex;align-items:stretch;gap:1rem;margin-top:2rem;margin-bottom:1rem;flex-wrap:wrap;}
+      .analysis-header .pitch-cta{margin:0;max-width:22rem;white-space:normal;text-align:center;font-size:clamp(1rem,3.5vw,1.125rem);line-height:1.3;display:flex;align-items:center;justify-content:center;}
       @media (max-width:700px){.analysis-header{flex-direction:column;align-items:flex-start;}.analysis-header .pitch-cta{margin-top:1rem;width:100%;}}
   .about-me-section{
     --accent:#2563eb; --ink:#0b1220;
@@ -737,7 +737,7 @@
     transform: translateY(-2px);
     box-shadow: 0 14px 32px rgba(37, 99, 235, .35);
   }
-.analysis-badge{display:flex;align-items:center;gap:0.6rem;background:rgba(37,99,235,0.1);border:0;border-radius:14px;padding:1rem 1.5rem;font-size:clamp(1rem,3.5vw,1.125rem);line-height:1.3;font-weight:600;color:var(--link);}
+.analysis-badge{display:flex;align-items:center;gap:0.6rem;background:rgba(37,99,235,0.1);border:0;border-radius:14px;padding:1rem 1.5rem;font-size:clamp(1rem,3.5vw,1.125rem);line-height:1.3;font-weight:600;color:var(--link);height:100%;}
 .counter-wrapper{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:2rem;margin:2rem 0 3rem;}
 .counter-card{position:relative;background:linear-gradient(to bottom right,rgba(255,255,255,0.9),rgba(245,250,255,0.9));backdrop-filter:blur(12px);padding:1.75rem;border-radius:1rem;box-shadow:0 10px 24px rgba(0,0,0,0.07);text-align:center;}
 .icon-wrapper{width:48px;height:48px;margin:0 auto 0.75rem;display:flex;align-items:center;justify-content:center;background:rgba(37,88,235,0.12);border-radius:50%;}


### PR DESCRIPTION
## Summary
- Center pitch section CTA text and allow it to stretch to full height
- Stretch pitch badge to match CTA height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b450e30cf88326a8993e8814a5358c