### PR TITLE
Remove redundant hero button and align analysis badge height

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,10 +290,6 @@
              <span class="lang lang-de">Demo ansehen</span>
              <span class="lang lang-en" hidden>Watch demo</span>
            </a>
-           <a class="btn secondary" href="#instrument">
-             <span class="lang lang-de">Mehr erfahren</span>
-             <span class="lang lang-en" hidden>Learn more</span>
-           </a>
          </div>
        </div>
       </section>

--- a/style.css
+++ b/style.css
@@ -737,7 +737,7 @@
     transform: translateY(-2px);
     box-shadow: 0 14px 32px rgba(37, 99, 235, .35);
   }
-.analysis-badge{display:flex;align-items:center;gap:0.6rem;background:rgba(37,99,235,0.1);border:0;border-radius:14px;padding:1rem 1.5rem;font-size:clamp(1rem,3.5vw,1.125rem);line-height:1.3;font-weight:600;color:var(--link);height:100%;}
+.analysis-badge{display:flex;align-items:center;gap:0.6rem;background:rgba(37,99,235,0.1);border:2px solid transparent;border-radius:14px;padding:1rem 1.5rem;font-size:clamp(1rem,3.5vw,1.125rem);line-height:1.3;font-weight:600;color:var(--link);height:100%;}
 .counter-wrapper{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:2rem;margin:2rem 0 3rem;}
 .counter-card{position:relative;background:linear-gradient(to bottom right,rgba(255,255,255,0.9),rgba(245,250,255,0.9));backdrop-filter:blur(12px);padding:1.75rem;border-radius:1rem;box-shadow:0 10px 24px rgba(0,0,0,0.07);text-align:center;}
 .icon-wrapper{width:48px;height:48px;margin:0 auto 0.75rem;display:flex;align-items:center;justify-content:center;background:rgba(37,88,235,0.12);border-radius:50%;}


### PR DESCRIPTION
## Summary
- remove extra "Mehr erfahren" button from hero section
- add transparent border to analysis badge so it matches CTA button height

## Testing
- `npx htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b457c684d88326a1d30c548c15d1b8