### PR TITLE
Update CTA styling and about link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1145,13 +1145,13 @@
 
   <!-- CTA -->
   <div class="cta-row">
-    <a href="mailto:kontakt@imhisdigital.de?subject=Kontaktanfrage%20Digitale%20Wirkung" class="btn primary">
+    <a class="btn-primary about-cta" href="mailto:kontakt@imhisdigital.de?subject=Kontaktanfrage%20Digitale%20Wirkung">
+      <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+        <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+        <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+      </svg>
       <span class="lang lang-de">Kontakt aufnehmen</span>
       <span class="lang lang-en" hidden>Get in touch</span>
-    </a>
-    <a href="#" class="btn secondary">
-      <span class="lang lang-de">ROI‑Report als PDF</span>
-      <span class="lang lang-en" hidden>Download ROI report (PDF)</span>
     </a>
   </div>
 </section>
@@ -1197,13 +1197,13 @@
         <span class="lang lang-en" hidden><a href="florian-eisold.html">Dr. Florian Eisold, M.D., B.Sc., LL.M.</a> – physician and developer of IMHIS</span>
       </cite>
 
-      <a class="btn-primary about-cta" href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">
+      <a class="btn-primary about-cta" href="florian-eisold.html">
         <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
           <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
           <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
         </svg>
-        <span class="lang lang-de">Kontakt aufnehmen</span>
-        <span class="lang lang-en" hidden>Get in touch</span>
+        <span class="lang lang-de">Über Dr. Florian Eisold</span>
+        <span class="lang lang-en" hidden>About Dr. Florian Eisold</span>
       </a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- match the benefit section contact CTA to the about-me button styling
- remove the ROI report button from the benefits call-to-action row
- retitle the about-me CTA to “Über Dr. Florian Eisold” and link it to the profile page

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68daac9413b883268d247499a7cbd1f4