### PR TITLE
Add benefit nav link and update benefit section

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -138,6 +138,12 @@
             </a>
           </li>
           <li>
+            <a href="/index.html#benefit">
+              <span class="lang lang-de">Nutzen</span>
+              <span class="lang lang-en" hidden>Benefit</span>
+            </a>
+          </li>
+          <li>
             <a href="/index.html#instrument">
               <span class="lang lang-de">Analyseinstrument</span>
               <span class="lang lang-en" hidden>Analysis Tool</span>

--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -116,6 +116,12 @@
             </a>
           </li>
           <li>
+            <a href="/index.html#benefit">
+              <span class="lang lang-de">Nutzen</span>
+              <span class="lang lang-en" hidden>Benefit</span>
+            </a>
+          </li>
+          <li>
             <a href="/index.html#instrument">
               <span class="lang lang-de">Analyseinstrument</span>
               <span class="lang lang-en" hidden>Analysis Tool</span>

--- a/impressum.html
+++ b/impressum.html
@@ -118,6 +118,12 @@
             </a>
           </li>
           <li>
+            <a href="/index.html#benefit">
+              <span class="lang lang-de">Nutzen</span>
+              <span class="lang lang-en" hidden>Benefit</span>
+            </a>
+          </li>
+          <li>
             <a href="/index.html#instrument">
               <span class="lang lang-de">Analyseinstrument</span>
               <span class="lang lang-en" hidden>Analysis Tool</span>

--- a/index.html
+++ b/index.html
@@ -411,6 +411,16 @@
         </a>
        </li>
        <li>
+        <a href="#benefit">
+         <span class="lang lang-de">
+          Nutzen
+         </span>
+         <span class="lang lang-en" hidden="">
+          Benefit
+         </span>
+        </a>
+       </li>
+       <li>
         <a href="#instrument">
          <span class="lang lang-de">
           Analyseinstrument
@@ -880,7 +890,7 @@
     </div>
    </section>
 
-    <section class="section-benefit">
+    <section class="section-benefit" id="benefit">
       <p class="eyebrow">
         <span class="lang lang-de">Mehrwert</span>
         <span class="lang lang-en" hidden>Benefit</span>
@@ -1159,17 +1169,6 @@
     </div>
   </div>
 
-  <!-- CTA -->
-  <div class="cta-row">
-    <a class="btn-primary about-cta" href="mailto:kontakt@imhisdigital.de?subject=Kontaktanfrage%20Digitale%20Wirkung">
-      <svg aria-hidden="true" class="cta-icon" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-        <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
-        <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
-      </svg>
-      <span class="lang lang-de">Kontakt aufnehmen</span>
-      <span class="lang lang-en" hidden>Get in touch</span>
-    </a>
-  </div>
 </section>
    
    <!-- About‑Me Section --> 


### PR DESCRIPTION
## Summary
- add a "Nutzen/Benefit" item to the main navigation across pages
- link the new navigation entry to the benefit section and add the anchor id
- remove the email call-to-action block from the benefit section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dace539f408326ad45eab68e670811