### PR TITLE
Enhance English marketing copy on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,12 +552,12 @@
           </span>
           <span class="lang lang-en" hidden>
             <span class="no-wrap">The <span class="accent">digital future</span> of healthcare</span><br/>
-            <span class="no-wrap">begins with the <span class="accent accent-alt">right analysis</span></span>
+            <span class="no-wrap">begins when <span class="accent accent-alt">insight sparks action</span></span>
           </span>
         </h1>
          <p>
            <span class="lang lang-de">IMHIS macht digitale Wirkung messbar: für <strong>mehr Zeit</strong> für Patienten, <strong>weniger Frust</strong> im Alltag – und Entscheidungen mit <strong>echtem Mehrwert.</strong></span>
-           <span class="lang lang-en" hidden>IMHIS makes digital impact measurable: <strong>more time</strong> for patients, <strong>less frustration</strong> in everyday life &ndash; and decisions with <strong>real added value.</strong></span>
+           <span class="lang lang-en" hidden>IMHIS turns digital potential into measurable impact: <strong>more time</strong> for patients, <strong>less friction</strong> on the ward &ndash; and decisions that drive <strong>confident progress.</strong></span>
          </p>
         <ul class="benefits" aria-label="Vorteile">
   <li class="benefit-chip">
@@ -625,7 +625,7 @@
         Echte digitale Wirkung
        </span>
        <span class="lang lang-en" hidden="">
-        Real digital impact
+        Digital impact, proven
        </span>
       </p>
       <h2 id="pitch-title">
@@ -633,7 +633,7 @@
         Jede Software verspricht digitale Wirkung. IMHIS belegt sie.
        </span>
        <span class="lang lang-en" hidden="">
-        Every software promises digital impact. IMHIS proves it.
+        Every platform promises digital impact. IMHIS delivers proof that wins decisions.
        </span>
       </h2>
       <p class="lead">
@@ -647,11 +647,11 @@
         öffnen – Schwächen erkennen, Stärken ausbauen, Wirkung sichern.
       </span>
       <span class="lang lang-en" hidden="">
-        With IMHIS you can open the
+        IMHIS lights up the
         <span class="black-box">
          black box
         </span>
-        of daily clinical routine—identify weaknesses, expand strengths, ensure impact.
+        of everyday clinical life&mdash;uncovering weak spots, amplifying strengths, and securing lasting impact.
       </span>
      </p>     <div class="analysis-header">
       <!-- Analysebeispiel: digitale Patientenkurve (Badge) -->
@@ -684,7 +684,7 @@
         Jetzt alle Effekte mit IMHIS sichtbar machen
        </span>
        <span class="lang lang-en" hidden>
-        Reveal the full impact with IMHIS now
+        Illuminate the full impact with IMHIS now
        </span>
       </a>
      </div>
@@ -901,13 +901,13 @@
           <span data-audience="clinic" hidden>Evidenz, die entscheidet</span>
         </span>
         <span class="lang lang-en" hidden>
-          <span data-audience="manufacturer">Evidence that sells</span>
-          <span data-audience="clinic" hidden>Evidence that guides decisions</span>
+          <span data-audience="manufacturer">Evidence that closes deals</span>
+          <span data-audience="clinic" hidden>Evidence that guides bold decisions</span>
         </span>
       </h2>
       <p class="lead">
         <span class="lang lang-de">Zeit, Geld, Impact – alles in einem Schritt</span>
-        <span class="lang lang-en" hidden>Time, money, impact—all in one go</span>
+        <span class="lang lang-en" hidden>Time, budget, and impact—unlocked in one move</span>
       </p>
 
   <!-- Audience‑Toggle -->
@@ -1039,7 +1039,7 @@
       </div>
       <p class="card-desc">
         <span class="lang lang-de">Use‑Cases mit Zahlen für Ihre Pitches und Ausschreibungen.</span>
-        <span class="lang lang-en" hidden>Use cases with numbers for your pitches and tenders.</span>
+        <span class="lang lang-en" hidden>Stories with numbers that electrify your pitches and bids.</span>
       </p>
     </div>
     <!-- Card 2 -->
@@ -1057,7 +1057,7 @@
       </div>
       <p class="card-desc">
         <span class="lang lang-de">Prioritäten aus Nutzersicht – nicht vom Whiteboard.</span>
-        <span class="lang lang-en" hidden>Priorities from the user perspective — not from the whiteboard.</span>
+        <span class="lang lang-en" hidden>Priorities straight from the ward — not from the whiteboard.</span>
       </p>
     </div>
     <!-- Card 3 -->
@@ -1074,7 +1074,7 @@
       </div>
       <p class="card-desc">
         <span class="lang lang-de">Wirkungs‑Kriterien, Referenzen und valide Nachweise.</span>
-        <span class="lang lang-en" hidden>Impact criteria, references, and solid evidence.</span>
+        <span class="lang lang-en" hidden>Impact criteria, reference wins, and undeniable proof.</span>
       </p>
     </div>
     <!-- Card 4 -->
@@ -1091,7 +1091,7 @@
       </div>
       <p class="card-desc">
         <span class="lang lang-de">„IMHIS Verified Impact“ auf Website und Sales‑Deck.</span>
-        <span class="lang lang-en" hidden>“IMHIS Verified Impact” for your website and sales deck.</span>
+        <span class="lang lang-en" hidden>Showcase “IMHIS Verified Impact” across your site and sales deck.</span>
       </p>
     </div>
   </div>
@@ -1109,11 +1109,11 @@
       </div>
       <div class="card-title">
         <span class="lang lang-de">Evidenz für Entscheidungen</span>
-        <span class="lang lang-en" hidden>Evidence for decisions</span>
+        <span class="lang lang-en" hidden>Evidence for decisive action</span>
       </div>
       <p class="card-desc">
         <span class="lang lang-de">Upgrade, Roll‑out, Budget: harte Zahlen statt Bauchgefühl.</span>
-        <span class="lang lang-en" hidden>Upgrade, roll-out, budget: hard numbers instead of gut feeling.</span>
+        <span class="lang lang-en" hidden>Upgrade, roll-out, budget—guided by hard evidence, not gut feeling.</span>
       </p>
     </div>
     <!-- Card 2 -->
@@ -1126,11 +1126,11 @@
       </div>
       <div class="card-title">
         <span class="lang lang-de">Prozesshebel sichtbar</span>
-        <span class="lang lang-en" hidden>Process levers made visible</span>
+        <span class="lang lang-en" hidden>Process levers illuminated</span>
       </div>
       <p class="card-desc">
         <span class="lang lang-de">Wo Zeit verloren geht. Wo Wirkung entsteht – und wie Sie sie nutzen.</span>
-        <span class="lang lang-en" hidden>Where time is lost. Where impact emerges — and how to harness it.</span>
+        <span class="lang lang-en" hidden>See where time slips away, where impact ignites—and how to capture it.</span>
       </p>
     </div>
     <!-- Card 3 -->
@@ -1142,11 +1142,11 @@
       </div>
       <div class="card-title">
         <span class="lang lang-de">Risiken minimieren</span>
-        <span class="lang lang-en" hidden>Minimise risks</span>
+        <span class="lang lang-en" hidden>De-risk transformation</span>
       </div>
       <p class="card-desc">
         <span class="lang lang-de">Medienbrüche, Usability und Infrastruktur klar priorisieren.</span>
-        <span class="lang lang-en" hidden>Prioritise media breaks, usability, and infrastructure with clarity.</span>
+        <span class="lang lang-en" hidden>Bring clarity to media breaks, usability, and infrastructure priorities.</span>
       </p>
     </div>
     <!-- Card 4 -->
@@ -1160,11 +1160,11 @@
       </div>
       <div class="card-title">
         <span class="lang lang-de">Akzeptanz sichern</span>
-        <span class="lang lang-en" hidden>Secure adoption</span>
+        <span class="lang lang-en" hidden>Secure lasting adoption</span>
       </div>
       <p class="card-desc">
         <span class="lang lang-de">Nutzerzufriedenheit als Frühwarnsystem für den Klinikalltag.</span>
-        <span class="lang lang-en" hidden>User satisfaction as an early warning system for everyday clinical life.</span>
+        <span class="lang lang-en" hidden>Turn user satisfaction into the early-warning system for daily clinical reality.</span>
       </p>
     </div>
   </div>
@@ -1195,15 +1195,15 @@
       <blockquote class="about-quote">
         <p class="quote-emphasis">
           <span class="lang lang-de">Ich habe IMHIS entwickelt, weil ich an eine Medizin glaube, in der Technologie wieder <span class="accent">dem Menschen dient</span>.</span>
-          <span class="lang lang-en" hidden>I developed IMHIS because I believe in medicine where technology <span class="accent">serves people</span> again.</span>
+          <span class="lang lang-en" hidden>I developed IMHIS because I believe in medicine where technology finally <span class="accent">serves people</span> again.</span>
         </p>
         <p class="quote-emphasis">
           <span class="lang lang-de">Nicht das System braucht unsere Zeit – <span class="accent">die Patienten tun es.</span></span>
-          <span class="lang lang-en" hidden>It's not the system that needs our time – <span class="accent">the patients do.</span></span>
+          <span class="lang lang-en" hidden>The system shouldn't take our time &ndash; <span class="accent">our patients deserve it.</span></span>
         </p>
         <p>
           <span class="lang lang-de">Was wir brauchen, ist eine Digitalisierung, die <span class="accent">spürbar entlastet</span> und <span class="accent">messbar wirkt</span>.</span>
-          <span class="lang lang-en" hidden>We need digitalisation that <span class="accent">provides tangible relief</span> and <span class="accent">has measurable impact</span>.</span>
+          <span class="lang lang-en" hidden>We need digitalisation that <span class="accent">delivers tangible relief</span> and <span class="accent">creates measurable impact</span>.</span>
         </p>
       </blockquote>
 
@@ -1233,7 +1233,7 @@
 
       <h2 id="instrument-title">
         <span class="lang lang-de">Ein Analyseinstrument für echten digitalen Fortschritt</span>
-        <span class="lang lang-en" hidden>An analysis tool for real digital progress</span>
+        <span class="lang lang-en" hidden>An analysis tool that powers real digital progress</span>
       </h2>
 
       <p class="body">
@@ -1242,7 +1242,7 @@
           <span class="emph">dem medizinischen Personal</span>.
         </span>
         <span class="lang lang-en" hidden>
-          <span class="emph">IMHIS</span> combines scientific precision with practical relevance: it reveals how digital systems truly impact healthcare—from the perspective of the people who work with them every day:
+          <span class="emph">IMHIS</span> fuses scientific precision with frontline reality: it reveals how digital systems truly reshape healthcare—from the voices of the people who work with them every day:
           <span class="emph">the medical staff</span>.
         </span>
       </p>
@@ -1253,7 +1253,7 @@
           <span class="accent">digitale Zukunft</span> führen.
         </span>
         <span class="lang lang-en" hidden>
-          This creates a solid foundation for decisions that lead today's healthcare into the
+          That builds the launchpad for decisions that carry today's healthcare into the
           <span class="accent">digital future</span>.
         </span>
       </p>
@@ -1269,10 +1269,10 @@
           <div class="benefit-content">
             <h3>
               <span class="lang lang-de">macht digitale Wirkung sichtbar</span>
-              <span class="lang lang-en" hidden>makes digital impact visible</span>
+              <span class="lang lang-en" hidden>makes digital impact impossible to ignore</span>
             </h3>
             <p class="lang lang-de">dort, wo sie wirklich zählt: am Menschen</p>
-            <p class="lang lang-en" hidden>where it truly counts: for people</p>
+            <p class="lang lang-en" hidden>exactly where it matters most: for people</p>
           </div>
         </div>
 
@@ -1285,10 +1285,10 @@
           <div class="benefit-content">
             <h3>
               <span class="lang lang-de">schafft Evidenz für die Entscheidungen von Morgen</span>
-              <span class="lang lang-en" hidden>creates evidence for tomorrow's decisions</span>
+              <span class="lang lang-en" hidden>creates evidence that powers tomorrow's decisions</span>
             </h3>
             <p class="lang lang-de">für echten digitalen Fortschritt</p>
-            <p class="lang lang-en" hidden>for real digital progress</p>
+            <p class="lang lang-en" hidden>fueling real digital progress</p>
           </div>
         </div>
 
@@ -1301,10 +1301,10 @@
           <div class="benefit-content">
             <h3>
               <span class="lang lang-de">schließt die Lücke zwischen Erwartung und Realität</span>
-              <span class="lang lang-en" hidden>closes the gap between expectation and reality</span>
+              <span class="lang lang-en" hidden>closes the gulf between ambition and reality</span>
             </h3>
             <p class="lang lang-de">damit Digitalisierung wirkt</p>
-            <p class="lang lang-en" hidden>so digitalization works</p>
+            <p class="lang lang-en" hidden>so digitalisation finally works</p>
           </div>
         </div>
       </div>
@@ -1365,7 +1365,7 @@
            Analysiert, wie digitale Lösungen Frequenz, Dauer und Ablauf klinischer Prozesse beeinflussen.
           </span>
           <span class="lang lang-en" hidden="">
-           Analyzes how digital solutions influence frequency, duration and flow of clinical processes.
+           Maps how digital solutions reshape the frequency, duration, and flow of clinical processes.
           </span>
          </p>
          <button class="dim-more-btn" type="button">
@@ -1395,7 +1395,7 @@
            IMHIS dekonstruiert Arbeitsprozesse in 26 Kategorien – entlang von Tätigkeit, Ort, Ablauf und Dauer. Damit jede Minute zählt.
           </span>
           <span class="lang lang-en" hidden="">
-           IMHIS deconstructs work processes into 26 categories — by activity, location, sequence and duration. So that every minute counts.
+           IMHIS breaks work processes into 26 categories&mdash;by activity, location, sequence, and duration&mdash;so every minute counts.
           </span>
          </p>
         </article>
@@ -1421,7 +1421,7 @@
            Misst Zuverlässigkeit, Performance und Usability der eingesetzten Systeme.
           </span>
           <span class="lang lang-en" hidden="">
-           Measures reliability, performance and usability of the deployed systems.
+           Measures the reliability, performance, and usability of your deployed systems.
           </span>
          </p>
          <button class="dim-more-btn" type="button">
@@ -1450,7 +1450,7 @@
            IMHIS übersetzt Technik in Wirkung – mit 21 gezielten Fragen zur Systemperformance im Alltag.
           </span>
           <span class="lang lang-en" hidden="">
-           IMHIS translates technology into impact — with 21 targeted questions about system performance in everyday life.
+           IMHIS translates technology into impact&mdash;with 21 targeted questions about system performance in everyday clinical reality.
           </span>
          </p>
         </article>
@@ -1476,7 +1476,7 @@
            Prüft Genauigkeit, Relevanz und Verständlichkeit der bereitgestellten Informationen.
           </span>
           <span class="lang lang-en" hidden="">
-           Checks accuracy, relevance and comprehensibility of the provided information.
+           Assesses whether information lands with accuracy, relevance, and clarity.
           </span>
          </p>
          <button class="dim-more-btn" type="button">
@@ -1497,7 +1497,7 @@
            Gute Informationen retten Leben. Schlechte gefährden sie.
           </span>
           <span class="lang lang-en" hidden="">
-           Good information saves lives. Poor information endangers them.
+           Good information saves lives. Poor information puts them at risk.
           </span>
          </h3>
          <p>
@@ -1505,7 +1505,7 @@
            IMHIS deckt auf, ob Systeme die richtigen Informationen zur richtigen Zeit liefern – gemessen mit 21 standardisierten Fragen.
           </span>
           <span class="lang lang-en" hidden="">
-           IMHIS reveals whether systems provide the right information at the right time — measured with 21 standardized questions.
+           IMHIS shows whether systems deliver the right insight at the right moment&mdash;measured with 21 standardised questions.
           </span>
          </p>
         </article>
@@ -1531,7 +1531,7 @@
            Zeigt, wie Systeme den intra- und interdisziplinären Austausch unterstützen.
           </span>
           <span class="lang lang-en" hidden="">
-           Shows how systems support intra- and interdisciplinary information exchange.
+           Shows how systems fuel intra- and interdisciplinary collaboration.
           </span>
          </p>
          <button class="dim-more-btn" type="button">
@@ -1560,7 +1560,7 @@
            IMHIS misst, wie gut digitale Systeme Zusammenarbeit ermöglichen – mit 12 gezielten Fragen zur Kommunikation und Koordination im Klinikalltag.
           </span>
           <span class="lang lang-en" hidden="">
-           IMHIS measures how well digital systems enable collaboration — with 12 targeted questions on communication and coordination in daily clinical practice.
+           IMHIS gauges how well digital systems enable collaboration&mdash;with 12 targeted questions on communication and coordination in daily clinical practice.
           </span>
          </p>
         </article>
@@ -1586,7 +1586,7 @@
            Bewertet Nutzen, Informationsqualität und Benutzeroberfläche aus Sicht der Anwender.
           </span>
           <span class="lang lang-en" hidden="">
-           Evaluates usefulness, information quality and user interface from the users' perspective.
+           Evaluates usefulness, information quality, and interface through the eyes of your users.
           </span>
          </p>
          <button class="dim-more-btn" type="button">
@@ -1607,7 +1607,7 @@
            Was nicht überzeugt, wird nicht genutzt.
           </span>
           <span class="lang lang-en" hidden="">
-           What doesn't convince won't be used.
+           What fails to convince simply won't be used.
           </span>
          </h3>
          <p>
@@ -1615,7 +1615,7 @@
            IMHIS prüft, ob Systeme überzeugen – oder im Alltag scheitern. 19 validierte Fragen zur Nutzerzufriedenheit.
           </span>
           <span class="lang lang-en" hidden="">
-           IMHIS checks whether systems convince—or fail in practice. 19 validated questions on user satisfaction.
+           IMHIS reveals whether systems win hearts—or break in practice. 19 validated questions on user satisfaction.
           </span>
          </p>
         </article>
@@ -1641,7 +1641,7 @@
            Erfasst mentale, körperliche und zeitliche Anforderungen sowie Leistung, Anstrengung und Frustration.
           </span>
           <span class="lang lang-en" hidden="">
-           Captures mental, physical and time demands as well as performance, effort and frustration.
+           Captures mental, physical, and time demands alongside performance, effort, and frustration.
           </span>
          </p>
          <button class="dim-more-btn" type="button">
@@ -1662,7 +1662,7 @@
            Energie gehört ans Patientenbett. Nicht in die Software.
           </span>
           <span class="lang lang-en" hidden="">
-           Energy belongs at the patient's bedside. Not in the software.
+           Energy belongs at the patient's bedside, not lost in software.
           </span>
          </h3>
          <p>
@@ -1670,7 +1670,7 @@
            IMHIS zeigt, ob Systeme entlasten – oder Kraft kosten. 21 standardisierte Fragen machen es messbar.
           </span>
           <span class="lang lang-en" hidden="">
-           IMHIS shows whether systems relieve — or drain energy. 21 standardized questions make it measurable.
+           IMHIS shows whether systems relieve—or drain—your teams. 21 standardised questions make it measurable.
           </span>
          </p>
         </article>
@@ -1820,7 +1820,7 @@
         Digitale Systeme – echte Wirkung
        </span>
        <span class="lang lang-en" hidden="">
-        Digitale Systeme – echte Wirkung
+        Digital Systems – Real Impact
        </span>
       </h2>
       <p class="book-subline">
@@ -1828,7 +1828,7 @@
         Die detaillierte Methodik und alle Messinstrumente finden Sie im Buch.
        </span>
        <span class="lang lang-en" hidden="">
-        The detailed methodology and all measurement instruments can be found in the book.
+        Explore the full methodology and every measurement instrument inside the book.
        </span>
       </p>
       <ul class="book-features">
@@ -1842,7 +1842,7 @@
           Fundierte Analysen für digitale Gesundheitslösungen
          </span>
          <span class="lang lang-en" hidden="">
-          Substantiated analyses for digital health solutions
+          Rigorous analyses for digital health solutions
          </span>
         </span>
        </li>
@@ -1856,7 +1856,7 @@
           Praxisnahes Messinstrument
          </span>
          <span class="lang lang-en" hidden="">
-          Practical measurement instrument
+          Practical measurement toolkit
          </span>
         </span>
        </li>
@@ -1870,7 +1870,7 @@
           Evidenzbasierte Empfehlungen
          </span>
          <span class="lang lang-en" hidden="">
-          Evidence-based recommendations
+          Evidence-based recommendations you can act on
          </span>
         </span>
        </li>
@@ -1882,7 +1882,7 @@
           Jetzt lesen
          </span>
          <span class="lang lang-en" hidden="">
-         Read now
+         Start reading now
          </span>
         </a>
         <button aria-controls="seller-list" aria-expanded="false" class="btn secondary" id="toggle-sellers" type="button">
@@ -1890,7 +1890,7 @@
           Weitere Händler anzeigen
          </span>
          <span class="lang lang-en" hidden="">
-          Show more retailers
+          View more retailers
          </span>
         </button>
        </div>
@@ -1921,7 +1921,7 @@
          Über viele Hochschulzugänge kostenlos als E-Book verfügbar
         </span>
         <span class="lang lang-en" hidden="">
-         Available free as an e-book through many university libraries
+         Available free as an e-book via many university libraries
         </span>
        </div>
        <ul class="seller-list" hidden="" id="seller-list">
@@ -1971,7 +1971,7 @@
      Analyse geplant?
     </span>
     <span class="lang lang-en" hidden="">
-     Planning an analysis?
+     Ready to plan an analysis?
     </span>
    </a>
   </footer>


### PR DESCRIPTION
## Summary
- Refresh the English hero pitch and benefit messaging with visionary, sales-focused language.
- Update analysis, dimension, and book sections to deliver more emotional, future-oriented copy across the English toggles.

## Testing
- Not run (static content).


------
https://chatgpt.com/codex/tasks/task_e_68dacf5967dc83268e73c2308b22efef