### PR TITLE
Set benefit calculator to default to yearly results

### DIFF
--- a/index.html
+++ b/index.html
@@ -973,11 +973,11 @@
 
     <!-- Perioden‑Umschalter -->
     <div class="period-toggle">
-      <button id="period-month" class="active">
+      <button id="period-month">
         <span class="lang lang-de">Monat</span>
         <span class="lang lang-en" hidden>Month</span>
       </button>
-      <button id="period-year">
+      <button id="period-year" class="active">
         <span class="lang lang-de">Jahr</span>
         <span class="lang lang-en" hidden>Year</span>
       </button>


### PR DESCRIPTION
## Summary
- make the benefit calculator load with the yearly period selected by default so the results reflect annual savings immediately

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dad145f11c83269069d9b549c0f2b2