### PR TITLE
Adopt profile header styling on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,91 +384,64 @@
     Skip to content
    </span>
   </a>
-  <header>
-   <nav aria-label="Hauptnavigation" class="nav">
+  <header class="site-header">
+   <div class="header-inner">
     <a aria-label="IMHIS Startseite" class="logo" href="#top">
-     <img alt="IMHIS Logo" data-alt-en="IMHIS logo" decoding="async" fetchpriority="high" height="74" src="assets/Logo_blau.svg" width="398"/>
+     <img alt="IMHIS Logo" data-alt-en="IMHIS logo" decoding="async" fetchpriority="high" height="40" src="assets/Logo_blau.svg" width="160"/>
     </a>
-    <div aria-label="Sprachauswahl" class="lang-switcher" role="group">
-     <button aria-label="Deutsch" aria-pressed="true" class="lang-btn" data-lang="de">DE</button>
-     <button aria-label="English" aria-pressed="false" class="lang-btn" data-lang="en">EN</button>
-    </div>
-    <!-- Hamburger bleibt für dein bestehendes JS -->
-    <button aria-controls="nav-links" aria-expanded="false" aria-label="Menü öffnen" class="nav-toggle" data-label-close-de="Menü schließen" data-label-close-en="Close menu" data-label-open-de="Menü öffnen" data-label-open-en="Open menu">
-     <span class="hamburger">
-     </span>
-    </button>
-    <!-- Nav-Links + neuer Punkt „Analysedimensionen“ -->
-      <ul class="nav-links" hidden="" id="nav-links">
-       <li>
-        <a href="#pitch">
-         <span class="lang lang-de">
-          Demo ansehen
-         </span>
-         <span class="lang lang-en" hidden="">
-          Watch demo
-         </span>
-        </a>
-       </li>
-       <li>
-        <a href="#benefit">
-         <span class="lang lang-de">
-          Nutzen
-         </span>
-         <span class="lang lang-en" hidden="">
-          Benefit
-         </span>
-        </a>
-       </li>
-       <li>
-        <a href="#instrument">
-         <span class="lang lang-de">
-          Analyseinstrument
-         </span>
-         <span class="lang lang-en" hidden="">
-          Analysis Tool
-         </span>
-        </a>
-       </li>
-     <li>
-      <a href="#linkedin">
-       <span class="lang lang-de">
-        News
-       </span>
-       <span class="lang lang-en" hidden="">
-        News
-       </span>
-      </a>
-     </li>
-     <!-- Aktionen (nur mobil sichtbar; Desktop separat rechts) -->
-     <li class="nav-actions--mobile">
-      <a class="btn secondary" href="#buch">
-       <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
-       </svg>
-       <span class="lang lang-de">
-        Buch ansehen
-       </span>
-       <span class="lang lang-en" hidden="">
-        View the book
-       </span>
-      </a>
-      <a class="btn primary" href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">
-       <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-        <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
-        <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
-       </svg>
-       <span class="lang lang-de">
-        Kostenlos anfragen
-       </span>
-       <span class="lang lang-en" hidden="">
-        Request free access
-       </span>
-      </a>
-     </li>
-    </ul>
-    <!-- Aktionen rechts (nur Desktop) -->
-    <div class="nav-actions">
+    <nav aria-label="Hauptnavigation" class="nav">
+     <button aria-controls="nav-links" aria-expanded="false" aria-label="Menü öffnen" class="nav-toggle" data-label-close-de="Menü schließen" data-label-close-en="Close menu" data-label-open-de="Menü öffnen" data-label-open-en="Open menu">
+      <span class="hamburger">
+      </span>
+     </button>
+     <ul class="nav-links" hidden="" id="nav-links">
+      <li>
+       <a href="#pitch">
+        <span class="lang lang-de">
+         Demo ansehen
+        </span>
+        <span class="lang lang-en" hidden="">
+         Watch demo
+        </span>
+       </a>
+      </li>
+      <li>
+       <a href="#benefit">
+        <span class="lang lang-de">
+         Nutzen
+        </span>
+        <span class="lang lang-en" hidden="">
+         Benefit
+        </span>
+       </a>
+      </li>
+      <li>
+       <a href="#instrument">
+        <span class="lang lang-de">
+         Analyseinstrument
+        </span>
+        <span class="lang lang-en" hidden="">
+         Analysis Tool
+        </span>
+       </a>
+      </li>
+      <li>
+       <a href="#linkedin">
+        <span class="lang lang-de">
+         News
+        </span>
+        <span class="lang lang-en" hidden="">
+         News
+        </span>
+       </a>
+      </li>
+     </ul>
+    </nav>
+    <div class="actions nav-actions">
+     <div aria-label="Sprachauswahl" class="lang-switcher" role="group">
+      <button aria-label="Deutsch" aria-pressed="true" class="lang-btn" data-lang="de">DE</button>
+      <button aria-label="English" aria-pressed="false" class="lang-btn" data-lang="en">EN</button>
+     </div>
      <a class="btn secondary" href="#buch">
       <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
@@ -493,7 +466,7 @@
       </span>
      </a>
     </div>
-   </nav>
+   </div>
   </header>
   
   <main id="main-content">

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -3,8 +3,11 @@
   --color-primary: #2563eb; /* kräftiges Blau analog zum IMHIS‑CI */
   --color-secondary: #0e1e40; /* dunkles Blau für Kontrast */
   --color-accent: #38bdf8; /* helles Blau für Highlights */
+  --color-accent-light: #e2e8f0; /* helle Variante für Hover-Effekte */
   --color-bg: #f9fafb; /* sehr helles Grau als Hintergrund */
+  --color-section: #ffffff; /* Karten- und Header-Hintergrund */
   --color-text: #1e293b; /* dunkler Grauton für Lesetext */
+  --color-text-light: #475569;
   --radius-large: 1.5rem;
   --nav-height: 80px;
 }
@@ -32,93 +35,249 @@ a {
   contain-intrinsic-size: auto 1000px;
 }
 
-header {
+/* Header */
+.site-header {
   position: sticky;
   top: 0;
   width: 100%;
   z-index: 1000;
-  backdrop-filter: saturate(180%) blur(12px);
-  background: rgba(255, 255, 255, 0.8);
-  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.05);
+  background: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid var(--color-accent-light);
+  backdrop-filter: saturate(180%) blur(18px);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
 }
 
-.logo {
+.site-header .header-inner {
+  width: min(92%, 1200px);
+  margin: 0 auto;
+  padding: 0.75rem 1.5rem;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
 }
 
-.nav-links {
+.site-header .logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.site-header .logo img {
+  display: block;
+  height: 40px;
+  width: auto;
+}
+
+.site-header .nav {
   display: flex;
   align-items: center;
-  gap: 2rem;
-}
-
-.nav-links a {
-  font-size: 1.125rem;
-  font-weight: 600;
-  white-space: nowrap;
-  transition: color 0.2s ease;
+  gap: 1rem;
+  flex: 1 1 auto;
+  justify-content: center;
   position: relative;
 }
 
-.nav-links a::after {
-  content: "";
-  position: absolute;
-  bottom: -4px;
-  left: 0;
-  width: 0;
-  height: 2px;
-  background: var(--color-primary);
-  transition: width 0.3s ease;
+.site-header .nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
-.nav-links a:hover::after {
-  width: 100%;
+.site-header .nav-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--color-text);
+  font-weight: 500;
+  font-size: 1.05rem;
+  text-decoration: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.65rem;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.site-header .nav-links a:hover,
+.site-header .nav-links a:focus-visible {
+  background: var(--color-accent-light);
+  color: var(--color-secondary);
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.18);
+  outline: none;
+}
+
+.site-header .actions {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.site-header .actions .btn {
+  border-radius: 999px !important;
+}
+
+.nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid var(--color-accent-light);
+  background: rgba(255, 255, 255, 0.88);
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.nav-toggle .hamburger {
+  position: relative;
+  width: 20px;
+  height: 2px;
+  background: var(--color-text);
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.nav-toggle .hamburger::before,
+.nav-toggle .hamburger::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: 20px;
+  height: 2px;
+  background: var(--color-text);
+  border-radius: 999px;
+  transition: transform 0.2s ease, background 0.2s ease, opacity 0.2s ease;
+}
+
+.nav-toggle .hamburger::before {
+  transform: translateY(-6px);
+}
+
+.nav-toggle .hamburger::after {
+  transform: translateY(6px);
+}
+
+.nav-toggle:hover,
+.nav-toggle:focus-visible,
+.nav-toggle.open {
+  background: linear-gradient(135deg, var(--color-primary), #1e40af);
+  border-color: transparent;
+  box-shadow: 0 12px 28px rgba(37, 99, 235, 0.35);
+  outline: none;
+}
+
+.nav-toggle:hover .hamburger,
+.nav-toggle:focus-visible .hamburger,
+.nav-toggle.open .hamburger {
+  background: transparent;
+}
+
+.nav-toggle:hover .hamburger::before,
+.nav-toggle:focus-visible .hamburger::before,
+.nav-toggle.open .hamburger::before {
+  transform: translateY(0) rotate(45deg);
+  background: #ffffff;
+}
+
+.nav-toggle:hover .hamburger::after,
+.nav-toggle:focus-visible .hamburger::after,
+.nav-toggle.open .hamburger::after {
+  transform: translateY(0) rotate(-45deg);
+  background: #ffffff;
+}
+
+.nav-toggle.open .hamburger::before,
+.nav-toggle.open .hamburger::after {
+  opacity: 1;
 }
 
 @media (max-width: 767px) {
-  .nav-links {
+  .site-header .header-inner {
+    padding: 0.75rem 1rem;
+    gap: 1rem;
+  }
+
+  .site-header .nav {
+    order: 2;
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  .site-header .nav-links {
     position: absolute;
-    top: var(--nav-height, 80px);
+    top: calc(100% + 0.75rem);
     left: 1rem;
     right: 1rem;
     flex-direction: column;
-    align-items: flex-start;
-    gap: 1.25rem;
+    align-items: stretch;
+    gap: 1rem;
     padding: 1.25rem;
-    background: #fff;
-    border-radius: var(--radius-large, 1.5rem);
-    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.1);
-    transform: translateY(-10px);
+    background: var(--color-section);
+    border: 1px solid var(--color-accent-light);
+    border-radius: var(--radius-large);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
+    transform: translateY(-12px);
     opacity: 0;
     pointer-events: none;
     transition: transform 0.3s ease, opacity 0.3s ease;
+    z-index: 1100;
   }
 
-  .nav-links.open {
+  .site-header .nav-links.open {
     transform: translateY(0);
     opacity: 1;
     pointer-events: auto;
   }
 
-  .nav-links li {
+  .site-header .nav-links li {
     width: 100%;
   }
 
-  .nav-links a {
+  .site-header .nav-links a {
     width: 100%;
-    display: block;
-    font-size: 1.1rem;
+    justify-content: space-between;
+    font-size: 1rem;
   }
 
-  .nav-links .btn {
-    display: inline-flex;
+  .site-header .actions {
+    order: 3;
     width: 100%;
-    border-radius: 14px !important;
+    justify-content: stretch;
+    gap: 0.75rem;
   }
 
-  .nav-links .btn::after {
-    display: none;
+  .site-header .actions .lang-switcher {
+    flex: 1 1 100%;
+    justify-content: center;
+  }
+
+  .site-header .actions .btn {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+}
+
+@media (min-width: 768px) {
+  .site-header .header-inner {
+    flex-wrap: nowrap;
+  }
+
+  .site-header .nav {
+    justify-content: center;
+  }
+
+  .site-header .actions {
+    flex-wrap: nowrap;
   }
 }
 
@@ -387,46 +546,6 @@ header {
   font-weight: 600;
 }
 
-@media (max-width: 767px) {
-  .lang-switcher {
-    margin-right: 1rem;
-  }
-  .nav-actions--mobile {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.75rem;
-  }
-  .nav-actions--mobile .btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    text-align: center;
-    white-space: nowrap;
-    font-size: 1.125rem;
-  }
-  .nav-links .btn::after {
-    display: none;
-  }
-  .nav-actions--mobile .btn.primary {
-    padding: 1rem 1.5rem;
-    background: linear-gradient(135deg, var(--color-primary), #1d4ed8);
-    color: #ffffff;
-    box-shadow: 0 10px 28px rgba(37, 99, 235, 0.25);
-    transition: all 0.25s ease;
-  }
-  .nav-actions--mobile .btn.primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 14px 32px rgba(37, 99, 235, 0.35);
-  }
-  .nav-actions--mobile .btn.secondary {
-    background: #ffffff;
-    color: var(--link);
-    border: 2px solid var(--link);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
-  }
-}
 
 /* Badge indicating free university e-book access */
 .trust-badge.free-access {


### PR DESCRIPTION
## Summary
- refactor the index header markup to match the profile page layout with the updated logo size and streamlined navigation
- refresh custom styles to support the new header design, responsive behaviour, and nav toggle interactions while dropping unused mobile CTA rules

## Testing
- Not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68dbf7a8bad0832685ab1336df97f164