### PR TITLE
Align index header CTA with profile page

### DIFF
--- a/index.html
+++ b/index.html
@@ -452,28 +452,17 @@
       <button aria-label="Deutsch" aria-pressed="true" class="lang-btn" data-lang="de">DE</button>
       <button aria-label="English" aria-pressed="false" class="lang-btn" data-lang="en">EN</button>
      </div>
-     <a class="btn secondary" href="#buch">
-      <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-       <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
-      </svg>
-      <span class="lang lang-de">
-       Buch ansehen
-      </span>
-      <span class="lang lang-en" hidden="">
-       View the book
-      </span>
-     </a>
      <a class="btn primary" href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">
       <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
        <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
        <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
       </svg>
       <span class="lang lang-de">
-       Kostenlos anfragen
-      </span>
-      <span class="lang lang-en" hidden="">
-       Request free access
-      </span>
+       Kontakt aufnehmen
+       </span>
+       <span class="lang lang-en" hidden="">
+       Get in touch
+       </span>
      </a>
     </div>
    </div>

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -104,6 +104,9 @@ a {
   border-radius: 0.5rem;
   transition: background 0.2s ease, color 0.2s ease;
 }
+.site-header .nav-links a::after {
+  display: none;
+}
 
 .site-header .nav-links a:hover,
 .site-header .nav-links a:focus-visible {
@@ -122,6 +125,13 @@ a {
 
 .site-header .actions .btn {
   border-radius: 999px !important;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  line-height: 1;
+}
+.site-header .actions .btn svg {
+  width: 18px;
+  height: 18px;
 }
 
 .nav-toggle {


### PR DESCRIPTION
## Summary
- remove the redundant "Buch ansehen" CTA from the index header
- rename the remaining CTA to "Kontakt aufnehmen"/"Get in touch" and keep the language toggle next to it
- match the header button sizing and navigation hover effect with the Florian Eisold page styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbfef789c083268c0c1897e220e86d