### PR TITLE
Adjust header language toggle placement

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -121,6 +121,15 @@ a {
   gap: 0.8rem;
   flex-wrap: wrap;
   justify-content: flex-end;
+  flex-direction: row;
+}
+
+.site-header .actions .lang-switcher {
+  order: 0;
+}
+
+.site-header .actions .btn {
+  order: 1;
 }
 
 .site-header .actions .btn {


### PR DESCRIPTION
## Summary
- ensure the header action bar keeps a left-to-right flow for controls
- force the language toggle to render before the contact CTA button

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc00f0d3ac83269d7db286ceed14b4