### PR TITLE
Align index header with profile page styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,8 +38,8 @@
   <link rel="preconnect" href="https://www.linkedin.com" crossorigin>
   <link rel="preconnect" href="https://media.licdn.com" crossorigin>
   <link as="font" crossorigin="" fetchpriority="high" href="https://fonts.gstatic.com/s/inter/v19/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2" rel="preload" type="font/woff2"/>
-  <link as="style" crossorigin="" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&amp;display=swap" rel="preload"/>
-  <link crossorigin="" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&amp;display=swap" rel="stylesheet"/>
+  <link as="style" crossorigin="" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;display=swap" rel="preload"/>
+  <link crossorigin="" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&amp;display=swap" rel="stylesheet"/>
   <!-- Stylesheet -->
   <link as="style" href="styles/main.min.css" onload="this.onload=null;this.rel='stylesheet'" rel="preload"/>
   <noscript>
@@ -1938,7 +1938,12 @@
   </main>
   <footer class="contact-footer" id="kontakt">
    <a class="btn primary footer-cta" href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">
-    <span aria-hidden="true" class="cta-icon">✉️</span>
+    <span aria-hidden="true" class="cta-icon">
+     <svg fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+      <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+      <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+     </svg>
+    </span>
     <span class="lang lang-de">
      Analyse geplant?
     </span>

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -13,12 +13,13 @@
   --color-text: #1e293b; /* dunkler Grauton für Lesetext */
   --color-text-light: #475569;
   --radius-large: 1.5rem;
-  --nav-height: 80px;
+  --nav-height: 72px;
 }
 
 body {
   margin: 0;
-  font-family: "Inter", sans-serif;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   color: var(--color-text);
   background: var(--color-bg);
   line-height: 1.6;
@@ -55,11 +56,11 @@ a {
   width: 92%;
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0.75rem 20px;
+  padding: 0.6rem 20px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1.5rem;
+  gap: 1.25rem;
   flex-wrap: wrap;
 }
 
@@ -78,7 +79,7 @@ a {
 .site-header .nav {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.85rem;
   flex: 1 1 auto;
   justify-content: center;
   position: relative;
@@ -100,8 +101,9 @@ a {
   color: var(--color-text);
   font-weight: 500;
   font-size: 1.1rem;
+  letter-spacing: -0.01em;
   text-decoration: none;
-  padding: 0.5rem 0.75rem;
+  padding: 0.4rem 0.65rem;
   border-radius: 0.5rem;
   transition: background 0.2s ease, color 0.2s ease;
 }
@@ -119,7 +121,7 @@ a {
 .site-header .actions {
   display: flex;
   align-items: center;
-  gap: 0.8rem;
+  gap: 0.65rem;
   flex-wrap: wrap;
   justify-content: flex-end;
   flex-direction: row;
@@ -135,9 +137,9 @@ a {
 
 .site-header .actions .btn {
   border-radius: 999px !important;
-  padding: 0.75rem 1.5rem;
-  font-size: 1rem;
-  line-height: 1;
+  padding: 0.6rem 1.35rem;
+  font-size: 0.95rem;
+  line-height: 1.1;
 }
 .site-header .actions .btn svg {
   width: 18px;
@@ -222,8 +224,8 @@ a {
 
 @media (max-width: 767px) {
   .site-header .header-inner {
-    padding: 0.75rem 1rem;
-    gap: 1rem;
+    padding: 0.65rem 1rem;
+    gap: 0.9rem;
   }
 
   .site-header .nav {
@@ -276,7 +278,7 @@ a {
     order: 3;
     width: 100%;
     justify-content: stretch;
-    gap: 0.75rem;
+    gap: 0.65rem;
   }
 
   .site-header .actions .lang-switcher {
@@ -480,6 +482,10 @@ a {
     display: inline-flex;
     align-items: center;
   }
+  .cta-icon svg {
+    width: 20px;
+    height: 20px;
+  }
 
   .footer-cta {
     gap: 0.6rem;
@@ -525,21 +531,21 @@ a {
 .lang-switcher {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.25rem;
+  gap: 0.2rem;
+  padding: 0.2rem;
   background: var(--color-section);
   border: 1px solid var(--color-border);
   border-radius: 999px;
 }
 
 .lang-btn {
-  padding: 0.35rem 0.85rem;
+  padding: 0.3rem 0.8rem;
   background: transparent;
   border: none;
   border-radius: 999px;
   color: var(--color-text);
   font-weight: 600;
-  font-size: 0.875rem;
+  font-size: 0.85rem;
   cursor: pointer;
   transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }


### PR DESCRIPTION
## Summary
- trim the index header spacing to match the profile header height
- load the Inter 500 weight and tune header typography for a calmer appearance
- reuse the header contact envelope icon for the primary footer call to action

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc0b123ad48326a2e857ec030eeb0b