### PR TITLE
Refine index header spacing and typography

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -13,7 +13,7 @@
   --color-text: #1e293b; /* dunkler Grauton für Lesetext */
   --color-text-light: #475569;
   --radius-large: 1.5rem;
-  --nav-height: 72px;
+  --nav-height: 64px;
 }
 
 body {
@@ -56,7 +56,7 @@ a {
   width: 92%;
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0.6rem 20px;
+  padding: 0.45rem 20px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -72,7 +72,7 @@ a {
 
 .site-header .logo img {
   display: block;
-  height: 40px;
+  height: 36px;
   width: auto;
 }
 
@@ -101,9 +101,8 @@ a {
   color: var(--color-text);
   font-weight: 500;
   font-size: 1.1rem;
-  letter-spacing: -0.01em;
   text-decoration: none;
-  padding: 0.4rem 0.65rem;
+  padding: 0.3rem 0.6rem;
   border-radius: 0.5rem;
   transition: background 0.2s ease, color 0.2s ease;
 }
@@ -121,7 +120,7 @@ a {
 .site-header .actions {
   display: flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.6rem;
   flex-wrap: wrap;
   justify-content: flex-end;
   flex-direction: row;
@@ -129,6 +128,7 @@ a {
 
 .site-header .actions .lang-switcher {
   order: 0;
+  padding: 0.2rem;
 }
 
 .site-header .actions .btn {
@@ -137,7 +137,7 @@ a {
 
 .site-header .actions .btn {
   border-radius: 999px !important;
-  padding: 0.6rem 1.35rem;
+  padding: 0.5rem 1.25rem;
   font-size: 0.95rem;
   line-height: 1.1;
 }
@@ -224,7 +224,7 @@ a {
 
 @media (max-width: 767px) {
   .site-header .header-inner {
-    padding: 0.65rem 1rem;
+    padding: 0.55rem 1rem;
     gap: 0.9rem;
   }
 
@@ -271,7 +271,7 @@ a {
   .site-header .nav-links a {
     width: 100%;
     justify-content: space-between;
-    font-size: 1rem;
+    font-size: 1.05rem;
   }
 
   .site-header .actions {


### PR DESCRIPTION
## Summary
- reduce the index header padding and logo height to keep the bar more compact
- align navigation and language switcher typography with the Florian Eisold page for visual consistency
- tune mobile header spacing and font sizing to preserve readability in the tighter layout

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc0e057e0c83268f3b66e768f39c0a