### PR TITLE
Refine header layout and mobile navigation

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -117,18 +117,6 @@
           />
         </a>
         <nav class="nav" aria-label="Hauptnavigation">
-          <button
-            class="nav-toggle"
-            aria-label="Menü öffnen"
-            aria-expanded="false"
-            aria-controls="nav-links"
-            data-label-open-de="Menü öffnen"
-            data-label-close-de="Menü schließen"
-            data-label-open-en="Open menu"
-            data-label-close-en="Close menu"
-          >
-            <span class="hamburger"></span>
-          </button>
           <ul class="nav-links" id="nav-links" hidden>
             <li>
               <a href="/index.html#pitch">
@@ -154,28 +142,44 @@
                 <span class="lang lang-en" hidden>News</span>
               </a>
             </li>
+            <li class="nav-cta">
+              <a href="/index.html#buch" class="btn secondary">
+                <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+                </svg>
+                <span class="lang lang-de">Buch ansehen</span>
+                <span class="lang lang-en" hidden>View the book</span>
+              </a>
+            </li>
+            <li class="nav-cta">
+              <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS" class="btn primary">
+                <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+                  <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+                  <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+                </svg>
+                <span class="lang lang-de">Kostenlos anfragen</span>
+                <span class="lang lang-en" hidden>Request free access</span>
+              </a>
+            </li>
           </ul>
         </nav>
-        <div class="actions nav-actions">
+        <div class="header-controls">
           <div class="lang-switcher" role="group" aria-label="Sprachauswahl">
             <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
             <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
           </div>
-          <a href="/index.html#buch" class="btn secondary">
-            <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
-            </svg>
-            <span class="lang lang-de">Buch ansehen</span>
-            <span class="lang lang-en" hidden>View the book</span>
-          </a>
-          <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS" class="btn primary">
-            <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-              <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
-              <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
-            </svg>
-            <span class="lang lang-de">Kostenlos anfragen</span>
-            <span class="lang lang-en" hidden>Request free access</span>
-          </a>
+          <button
+            class="nav-toggle"
+            aria-label="Menü öffnen"
+            aria-expanded="false"
+            aria-controls="nav-links"
+            data-label-open-de="Menü öffnen"
+            data-label-close-de="Menü schließen"
+            data-label-open-en="Open menu"
+            data-label-close-en="Close menu"
+          >
+            <span class="hamburger"></span>
+          </button>
         </div>
       </div>
     </header>

--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -673,18 +673,6 @@
       </a>
       <!-- Navigation -->
       <nav class="nav" aria-label="Hauptnavigation">
-        <button
-          class="nav-toggle"
-          aria-label="Menü öffnen"
-          aria-expanded="false"
-          aria-controls="nav-links"
-          data-label-open-de="Menü öffnen"
-          data-label-close-de="Menü schließen"
-          data-label-open-en="Open menu"
-          data-label-close-en="Close menu"
-        >
-          <span class="hamburger"></span>
-        </button>
         <ul class="nav-links" id="nav-links" hidden>
           <li>
             <a href="#hero">
@@ -710,18 +698,32 @@
               <span class="lang lang-en" hidden>View demo</span>
             </a>
           </li>
+          <li class="nav-cta">
+            <a href="mailto:florian.eisold@icloud.com" class="btn secondary">
+              <span class="lang lang-de">Kontakt aufnehmen</span>
+              <span class="lang lang-en" hidden>Get in touch</span>
+            </a>
+          </li>
         </ul>
       </nav>
       <!-- Aktionen rechts -->
-      <div class="actions nav-actions">
+      <div class="header-controls">
         <div aria-label="Sprachauswahl" class="lang-switcher" role="group">
           <button aria-label="Deutsch" aria-pressed="true" class="lang-btn" data-lang="de">DE</button>
           <button aria-label="English" aria-pressed="false" class="lang-btn" data-lang="en">EN</button>
         </div>
-        <a href="mailto:florian.eisold@icloud.com" class="btn secondary">
-          <span class="lang lang-de">Kontakt aufnehmen</span>
-          <span class="lang lang-en" hidden>Get in touch</span>
-        </a>
+        <button
+          class="nav-toggle"
+          aria-label="Menü öffnen"
+          aria-expanded="false"
+          aria-controls="nav-links"
+          data-label-open-de="Menü öffnen"
+          data-label-close-de="Menü schließen"
+          data-label-open-en="Open menu"
+          data-label-close-en="Close menu"
+        >
+          <span class="hamburger"></span>
+        </button>
       </div>
     </div>
   </header>

--- a/impressum.html
+++ b/impressum.html
@@ -97,18 +97,6 @@
           />
         </a>
         <nav class="nav" aria-label="Hauptnavigation">
-          <button
-            class="nav-toggle"
-            aria-label="Menü öffnen"
-            aria-expanded="false"
-            aria-controls="nav-links"
-            data-label-open-de="Menü öffnen"
-            data-label-close-de="Menü schließen"
-            data-label-open-en="Open menu"
-            data-label-close-en="Close menu"
-          >
-            <span class="hamburger"></span>
-          </button>
           <ul class="nav-links" id="nav-links" hidden>
             <li>
               <a href="/index.html#pitch">
@@ -134,28 +122,44 @@
                 <span class="lang lang-en" hidden>News</span>
               </a>
             </li>
+            <li class="nav-cta">
+              <a href="/index.html#buch" class="btn secondary">
+                <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+                </svg>
+                <span class="lang lang-de">Buch ansehen</span>
+                <span class="lang lang-en" hidden>View the book</span>
+              </a>
+            </li>
+            <li class="nav-cta">
+              <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS" class="btn primary">
+                <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+                  <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+                  <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+                </svg>
+                <span class="lang lang-de">Kostenlos anfragen</span>
+                <span class="lang lang-en" hidden>Request free access</span>
+              </a>
+            </li>
           </ul>
         </nav>
-        <div class="actions nav-actions">
+        <div class="header-controls">
           <div class="lang-switcher" role="group" aria-label="Sprachauswahl">
             <button class="lang-btn" data-lang="de" aria-label="Deutsch" aria-pressed="true">DE</button>
             <button class="lang-btn" data-lang="en" aria-label="English" aria-pressed="false">EN</button>
           </div>
-          <a href="/index.html#buch" class="btn secondary">
-            <svg aria-hidden="true" fill="none" height="20" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.966 8.966 0 006 3.75a9.01 9.01 0 00-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292 9.01 9.01 0 013 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
-            </svg>
-            <span class="lang lang-de">Buch ansehen</span>
-            <span class="lang lang-en" hidden>View the book</span>
-          </a>
-          <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS" class="btn primary">
-            <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-              <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
-              <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
-            </svg>
-            <span class="lang lang-de">Kostenlos anfragen</span>
-            <span class="lang lang-en" hidden>Request free access</span>
-          </a>
+          <button
+            class="nav-toggle"
+            aria-label="Menü öffnen"
+            aria-expanded="false"
+            aria-controls="nav-links"
+            data-label-open-de="Menü öffnen"
+            data-label-close-de="Menü schließen"
+            data-label-open-en="Open menu"
+            data-label-close-en="Close menu"
+          >
+            <span class="hamburger"></span>
+          </button>
         </div>
       </div>
     </header>

--- a/index.html
+++ b/index.html
@@ -390,10 +390,6 @@
      <img alt="IMHIS Logo" data-alt-en="IMHIS logo" decoding="async" fetchpriority="high" height="40" src="assets/Logo_blau.svg" width="160"/>
     </a>
     <nav aria-label="Hauptnavigation" class="nav">
-     <button aria-controls="nav-links" aria-expanded="false" aria-label="Menü öffnen" class="nav-toggle" data-label-close-de="Menü schließen" data-label-close-en="Close menu" data-label-open-de="Menü öffnen" data-label-open-en="Open menu">
-      <span class="hamburger">
-      </span>
-     </button>
      <ul class="nav-links" hidden="" id="nav-links">
       <li>
        <a href="#pitch">
@@ -445,25 +441,31 @@
         </span>
        </a>
       </li>
+      <li class="nav-cta">
+       <a class="btn primary" href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">
+        <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+         <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
+         <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
+        </svg>
+        <span class="lang lang-de">
+         Kontakt aufnehmen
+        </span>
+        <span class="lang lang-en" hidden="">
+         Get in touch
+        </span>
+       </a>
+      </li>
      </ul>
     </nav>
-    <div class="actions nav-actions">
+    <div class="header-controls">
      <div aria-label="Sprachauswahl" class="lang-switcher" role="group">
       <button aria-label="Deutsch" aria-pressed="true" class="lang-btn" data-lang="de">DE</button>
       <button aria-label="English" aria-pressed="false" class="lang-btn" data-lang="en">EN</button>
      </div>
-     <a class="btn primary" href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">
-      <svg aria-hidden="true" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-       <rect height="14" rx="2" ry="2" stroke="currentColor" stroke-linejoin="round" stroke-width="2" width="18" x="3" y="5"></rect>
-       <path d="M3 8l9 6 9-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></path>
-      </svg>
-      <span class="lang lang-de">
-       Kontakt aufnehmen
-       </span>
-       <span class="lang lang-en" hidden="">
-       Get in touch
-       </span>
-     </a>
+     <button aria-controls="nav-links" aria-expanded="false" aria-label="Menü öffnen" class="nav-toggle" data-label-close-de="Menü schließen" data-label-close-en="Close menu" data-label-open-de="Menü öffnen" data-label-open-en="Open menu">
+      <span class="hamburger">
+      </span>
+     </button>
     </div>
    </div>
   </header>

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -61,7 +61,6 @@ a {
   align-items: center;
   justify-content: space-between;
   gap: 1.25rem;
-  flex-wrap: wrap;
 }
 
 .site-header .logo {
@@ -79,10 +78,10 @@ a {
 .site-header .nav {
   display: flex;
   align-items: center;
-  gap: 0.85rem;
-  flex: 1 1 auto;
+  flex: 1 1 0%;
   justify-content: center;
   position: relative;
+  min-width: 0;
 }
 
 .site-header .nav-links {
@@ -117,41 +116,31 @@ a {
   outline: none;
 }
 
-.site-header .actions {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  flex-direction: row;
-}
-
-.site-header .actions .lang-switcher {
-  order: 0;
-  padding: 0.2rem;
-}
-
-.site-header .actions .btn {
-  order: 1;
-}
-
-.site-header .actions .btn {
-  border-radius: 999px !important;
-  padding: 0.5rem 1.25rem;
+.site-header .nav-links .nav-cta .btn {
+  justify-content: center;
+  padding: 0.5rem 1.35rem;
   font-size: 0.95rem;
-  line-height: 1.1;
+  white-space: nowrap;
 }
-.site-header .actions .btn svg {
-  width: 18px;
-  height: 18px;
+
+.site-header .header-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.site-header .header-controls .nav-toggle {
+  flex-shrink: 0;
 }
 
 .nav-toggle {
   display: none;
   align-items: center;
   justify-content: center;
-  width: 44px;
-  height: 44px;
+  width: 40px;
+  height: 40px;
   border-radius: 999px;
   border: 1px solid var(--color-accent-light);
   background: rgba(255, 255, 255, 0.88);
@@ -225,24 +214,37 @@ a {
 @media (max-width: 767px) {
   .site-header .header-inner {
     padding: 0.55rem 1rem;
-    gap: 0.9rem;
+    gap: 0.75rem;
+    position: relative;
   }
 
   .site-header .nav {
-    order: 2;
-    width: 100%;
-    justify-content: space-between;
+    flex: 1 1 auto;
   }
 
   .nav-toggle {
     display: inline-flex;
   }
 
+  .site-header .header-controls {
+    gap: 0.3rem;
+  }
+
+  .site-header .header-controls .lang-switcher {
+    padding: 0.1rem 0.25rem;
+  }
+
+  .site-header .header-controls .lang-btn {
+    font-size: 0.7rem;
+    padding: 0.2rem 0.55rem;
+  }
+
   .site-header .nav-links {
     position: absolute;
     top: calc(100% + 0.75rem);
-    left: 1rem;
-    right: 1rem;
+    left: 50%;
+    transform: translate(-50%, -12px);
+    width: min(22rem, calc(100vw - 2rem));
     flex-direction: column;
     align-items: stretch;
     gap: 1rem;
@@ -251,7 +253,6 @@ a {
     border: 1px solid var(--color-accent-light);
     border-radius: var(--radius-large);
     box-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
-    transform: translateY(-12px);
     opacity: 0;
     pointer-events: none;
     transition: transform 0.3s ease, opacity 0.3s ease;
@@ -259,7 +260,7 @@ a {
   }
 
   .site-header .nav-links.open {
-    transform: translateY(0);
+    transform: translate(-50%, 0);
     opacity: 1;
     pointer-events: auto;
   }
@@ -274,35 +275,24 @@ a {
     font-size: 1.05rem;
   }
 
-  .site-header .actions {
-    order: 3;
+  .site-header .nav-links .nav-cta .btn {
     width: 100%;
-    justify-content: stretch;
-    gap: 0.65rem;
-  }
-
-  .site-header .actions .lang-switcher {
-    flex: 1 1 100%;
-    justify-content: center;
-  }
-
-  .site-header .actions .btn {
-    flex: 1 1 auto;
     justify-content: center;
   }
 }
 
 @media (min-width: 768px) {
   .site-header .header-inner {
-    flex-wrap: nowrap;
+    gap: 1.75rem;
   }
 
-  .site-header .nav {
-    justify-content: center;
+  .site-header .header-controls .lang-switcher {
+    padding: 0.15rem 0.35rem;
   }
 
-  .site-header .actions {
-    flex-wrap: nowrap;
+  .site-header .header-controls .lang-btn {
+    font-size: 0.8rem;
+    padding: 0.25rem 0.6rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- realign the header so the language toggle sits beside the burger control and shrink the controls for mobile
- move the contact CTA into the navigation menu and style header controls across pages
- update the legal and profile pages to reuse the refreshed header markup

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc11e7a0a483269c47aa6030bb87dd