### PR TITLE
Fix sticky header growth and align mobile navigation

### DIFF
--- a/scripts/main.min.js
+++ b/scripts/main.min.js
@@ -1,2 +1,343 @@
-"use strict";(()=>{const e=document.querySelectorAll(".lang-btn"),t=document.querySelectorAll(".lang-de"),n=document.querySelectorAll(".lang-en"),a=document.querySelectorAll("[data-alt-en]"),o=document.querySelector(".nav-toggle");function s(s){if(document.documentElement.lang===s)return;const c="en"===s;document.documentElement.lang=s;for(const e of t)e.hidden=c;for(const e of n)e.hidden=!c;for(const t of e){const e=t.dataset.lang===s;t.setAttribute("aria-pressed",e)}if(o){const e=c?"En":"De",t=`label${o.classList.contains("open")?"Close":"Open"}${e}`,n=o.dataset[t];n&&o.setAttribute("aria-label",n)}for(const e of a){e.dataset.altDe||(e.dataset.altDe=e.getAttribute("alt")||"");const t=c?e.dataset.altEn:e.dataset.altDe;e.setAttribute("alt",t)}try{localStorage.setItem("lang",s)}catch{}window.dispatchEvent(new Event("imhis-language-change"))}document.addEventListener("click",e=>{const t=e.target.closest(".lang-btn");t&&s(t.dataset.lang)},{passive:!0}),s(function(){try{const e=localStorage.getItem("lang");if("de"===e||"en"===e)return e}catch{}return navigator.language?.startsWith("en")?"en":"de"}())})(),(()=>{const e=document.querySelector(".nav-toggle"),t=document.querySelector(".nav-links");if(e&&t){function n(t){const n="en"===document.documentElement.lang?"En":"De",a=t?`labelClose${n}`:`labelOpen${n}`,o=e.dataset[a];o&&e.setAttribute("aria-label",o)}let a;const o=window.matchMedia("(min-width: 768px)");function s(){t.classList.remove("open"),t.hidden=!o.matches,e.classList.remove("open"),e.setAttribute("aria-expanded","false"),n(!1),a?.abort(),a=null}function c(){t.hidden=!1,t.classList.add("open"),e.classList.add("open"),e.setAttribute("aria-expanded","true"),n(!0),a=new AbortController,document.addEventListener("click",l,{signal:a.signal,passive:!0}),document.addEventListener("keydown",d,{signal:a.signal})}function r(){t.classList.contains("open")?s():c()}function l(n){t.contains(n.target)||e.contains(n.target)||s()}function d(e){"Escape"===e.key&&s()}function i(e){s(),t.hidden=!e.matches}i(o),o.addEventListener("change",i),e.addEventListener("click",r),n(!1),t.addEventListener("click",e=>{e.target.closest("a")&&s()})}})(),(()=>{const e=document.getElementById("toggle-sellers"),t=document.getElementById("seller-list");if(e&&t){const n=()=>{const n=t.classList.toggle("open");return e.setAttribute("aria-expanded",n),t.hidden=!n,n},a=a=>{!t.classList.contains("open")||t.contains(a.target)||e.contains(a.target)||n()},o=e=>{"Escape"===e.key&&t.classList.contains("open")&&n()};let s;e.addEventListener("click",()=>{n()?(s=new AbortController,document.addEventListener("click",a,{signal:s.signal,passive:!0}),document.addEventListener("keydown",o,{signal:s.signal})):(s?.abort(),s=null)})}})(),(()=>{function e(){!function(e){const t=document.createTreeWalker(e,NodeFilter.SHOW_TEXT),n=[];for(;t.nextNode();){const e=t.currentNode,a=e.parentElement;a&&"SCRIPT"!==a.tagName&&"STYLE"!==a.tagName&&"STRONG"!==a.tagName&&n.push(e)}for(const e of n){const t=e.nodeValue;if(t.includes("IMHIS")){const n=t.split("IMHIS"),a=document.createDocumentFragment();for(let e=0;e<n.length;e++)if(n[e]&&a.appendChild(document.createTextNode(n[e])),e<n.length-1){const e=document.createElement("strong");e.textContent="IMHIS",a.appendChild(e)}e.parentNode.replaceChild(a,e)}}}(document.body)}document.addEventListener("DOMContentLoaded",e),window.addEventListener("imhis-language-change",e)})();
-(()=>{const e=document.documentElement;let t;const n=()=>{const t=document.querySelector(".site-header")||document.querySelector("header");if(!t)return;const n=Math.ceil(t.getBoundingClientRect().height);n&&e.style.setProperty("--nav-height",`${n}px`)};const a=()=>{t&&cancelAnimationFrame(t),t=requestAnimationFrame(n)};window.addEventListener("resize",a,{passive:!0}),window.addEventListener("load",a),window.addEventListener("imhis-language-change",a),document.addEventListener("DOMContentLoaded",()=>{a();const e=document.querySelector(".site-header")||document.querySelector("header");if(e&&"ResizeObserver"in window){const t=new ResizeObserver(a);t.observe(e)}}),a()})();
+"use strict";
+(() => {
+  const languageButtons = document.querySelectorAll(".lang-btn");
+  const germanElements = document.querySelectorAll(".lang-de");
+  const englishElements = document.querySelectorAll(".lang-en");
+  const altElements = document.querySelectorAll("[data-alt-en]");
+  const navToggle = document.querySelector(".nav-toggle");
+
+  const updateToggleLabel = (isOpen) => {
+    if (!navToggle) return;
+    const suffix = document.documentElement.lang === "en" ? "En" : "De";
+    const key = `label${isOpen ? "Close" : "Open"}${suffix}`;
+    const label = navToggle.dataset[key];
+    if (label) {
+      navToggle.setAttribute("aria-label", label);
+    }
+  };
+
+  const switchLanguage = (lang) => {
+    if (!lang || document.documentElement.lang === lang) {
+      return;
+    }
+
+    const isEnglish = lang === "en";
+    document.documentElement.lang = lang;
+
+    germanElements.forEach((element) => {
+      element.hidden = isEnglish;
+    });
+
+    englishElements.forEach((element) => {
+      element.hidden = !isEnglish;
+    });
+
+    languageButtons.forEach((button) => {
+      button.setAttribute("aria-pressed", String(button.dataset.lang === lang));
+    });
+
+    updateToggleLabel(navToggle ? navToggle.classList.contains("open") : false);
+
+    altElements.forEach((element) => {
+      if (!element.dataset.altDe) {
+        element.dataset.altDe = element.getAttribute("alt") || "";
+      }
+      const nextAlt = isEnglish ? element.dataset.altEn : element.dataset.altDe;
+      if (typeof nextAlt === "string") {
+        element.setAttribute("alt", nextAlt);
+      }
+    });
+
+    try {
+      localStorage.setItem("lang", lang);
+    } catch (error) {
+      // Ignore storage issues (e.g. private mode)
+    }
+
+    window.dispatchEvent(new Event("imhis-language-change"));
+  };
+
+  document.addEventListener(
+    "click",
+    (event) => {
+      const target = event.target instanceof Element ? event.target : null;
+      const button = target ? target.closest(".lang-btn") : null;
+      if (button) {
+        switchLanguage(button.dataset.lang);
+      }
+    },
+    { passive: true }
+  );
+
+  const initialLanguage = (() => {
+    try {
+      const stored = localStorage.getItem("lang");
+      if (stored === "de" || stored === "en") {
+        return stored;
+      }
+    } catch (error) {
+      // Ignore storage errors and fall back to navigator language
+    }
+    return navigator.language && navigator.language.startsWith("en") ? "en" : "de";
+  })();
+
+  switchLanguage(initialLanguage);
+})();
+
+(() => {
+  const navToggle = document.querySelector(".nav-toggle");
+  const navLinks = document.querySelector(".nav-links");
+  if (!navToggle || !navLinks) {
+    return;
+  }
+
+  const mediaQuery = window.matchMedia("(min-width: 768px)");
+  let abortController;
+
+  const updateToggleLabel = (isOpen) => {
+    const suffix = document.documentElement.lang === "en" ? "En" : "De";
+    const key = `label${isOpen ? "Close" : "Open"}${suffix}`;
+    const label = navToggle.dataset[key];
+    if (label) {
+      navToggle.setAttribute("aria-label", label);
+    }
+  };
+
+  const dispatchHeaderResize = () => {
+    window.dispatchEvent(new Event("imhis-header-resize"));
+  };
+
+  const closeMenu = () => {
+    navLinks.classList.remove("open");
+    navLinks.hidden = !mediaQuery.matches;
+    navToggle.classList.remove("open");
+    navToggle.setAttribute("aria-expanded", "false");
+    updateToggleLabel(false);
+    if (abortController) {
+      abortController.abort();
+      abortController = undefined;
+    }
+    dispatchHeaderResize();
+  };
+
+  const handleOutsideClick = (event) => {
+    const target = event.target instanceof Node ? event.target : null;
+    if (target && (navLinks.contains(target) || navToggle.contains(target))) {
+      return;
+    }
+    closeMenu();
+  };
+
+  const handleEscape = (event) => {
+    if (event.key === "Escape") {
+      closeMenu();
+    }
+  };
+
+  const openMenu = () => {
+    navLinks.hidden = false;
+    navLinks.classList.add("open");
+    navToggle.classList.add("open");
+    navToggle.setAttribute("aria-expanded", "true");
+    updateToggleLabel(true);
+    abortController = new AbortController();
+    document.addEventListener("click", handleOutsideClick, {
+      signal: abortController.signal,
+      passive: true,
+    });
+    document.addEventListener("keydown", handleEscape, {
+      signal: abortController.signal,
+    });
+    dispatchHeaderResize();
+  };
+
+  const toggleMenu = () => {
+    if (navLinks.classList.contains("open")) {
+      closeMenu();
+    } else {
+      openMenu();
+    }
+  };
+
+  const handleMediaChange = (event) => {
+    if (event.matches) {
+      navLinks.hidden = false;
+    }
+    closeMenu();
+    navLinks.hidden = !event.matches;
+  };
+
+  mediaQuery.addEventListener("change", handleMediaChange);
+
+  navToggle.addEventListener("click", toggleMenu);
+  navLinks.addEventListener("click", (event) => {
+    const target = event.target instanceof Element ? event.target : null;
+    if (target && target.closest("a")) {
+      closeMenu();
+    }
+  });
+
+  window.addEventListener("imhis-language-change", () => {
+    updateToggleLabel(navToggle.classList.contains("open"));
+  });
+
+  updateToggleLabel(false);
+  navLinks.hidden = !mediaQuery.matches;
+})();
+
+(() => {
+  const toggleButton = document.getElementById("toggle-sellers");
+  const sellerList = document.getElementById("seller-list");
+  if (!toggleButton || !sellerList) {
+    return;
+  }
+
+  let abortController;
+
+  const detachListeners = () => {
+    if (abortController) {
+      abortController.abort();
+      abortController = undefined;
+    }
+  };
+
+  const setListState = (isOpen) => {
+    sellerList.classList.toggle("open", isOpen);
+    sellerList.hidden = !isOpen;
+    toggleButton.setAttribute("aria-expanded", String(isOpen));
+
+    detachListeners();
+
+    if (isOpen) {
+      abortController = new AbortController();
+      document.addEventListener("click", handleOutsideClick, {
+        signal: abortController.signal,
+        passive: true,
+      });
+      document.addEventListener("keydown", handleEscape, {
+        signal: abortController.signal,
+      });
+    }
+  };
+
+  const handleOutsideClick = (event) => {
+    const target = event.target instanceof Node ? event.target : null;
+    if (target && (sellerList.contains(target) || toggleButton.contains(target))) {
+      return;
+    }
+    setListState(false);
+  };
+
+  const handleEscape = (event) => {
+    if (event.key === "Escape") {
+      setListState(false);
+    }
+  };
+
+  toggleButton.addEventListener("click", () => {
+    const nextState = !sellerList.classList.contains("open");
+    setListState(nextState);
+  });
+
+  setListState(sellerList.classList.contains("open"));
+})();
+
+(() => {
+  const highlightIMHIS = (root) => {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const nodes = [];
+
+    while (walker.nextNode()) {
+      const node = walker.currentNode;
+      const parent = node.parentElement;
+      if (!parent || parent.tagName === "SCRIPT" || parent.tagName === "STYLE" || parent.tagName === "STRONG") {
+        continue;
+      }
+      if (node.nodeValue && node.nodeValue.includes("IMHIS")) {
+        nodes.push(node);
+      }
+    }
+
+    nodes.forEach((textNode) => {
+      const parts = textNode.nodeValue ? textNode.nodeValue.split("IMHIS") : [];
+      if (parts.length === 0) {
+        return;
+      }
+      const fragment = document.createDocumentFragment();
+      parts.forEach((part, index) => {
+        if (part) {
+          fragment.appendChild(document.createTextNode(part));
+        }
+        if (index < parts.length - 1) {
+          const strong = document.createElement("strong");
+          strong.textContent = "IMHIS";
+          fragment.appendChild(strong);
+        }
+      });
+      if (textNode.parentNode) {
+        textNode.parentNode.replaceChild(fragment, textNode);
+      }
+    });
+  };
+
+  const run = () => {
+    highlightIMHIS(document.body);
+  };
+
+  document.addEventListener("DOMContentLoaded", run);
+  window.addEventListener("imhis-language-change", run);
+})();
+
+(() => {
+  const docEl = document.documentElement;
+  let frameId = 0;
+  let lastHeight;
+
+  const parseCssValue = (property, fallback) => {
+    const value = parseFloat(getComputedStyle(docEl).getPropertyValue(property));
+    return Number.isFinite(value) ? value : fallback;
+  };
+
+  const measureHeader = () => {
+    const header = document.querySelector(".site-header") || document.querySelector("header");
+    if (!header) {
+      return;
+    }
+    const measured = Math.ceil(header.getBoundingClientRect().height);
+    if (!measured) {
+      return;
+    }
+
+    const min = parseCssValue("--nav-height-min", 64);
+    const max = parseCssValue("--nav-height-max", 144);
+    const clamped = Math.min(Math.max(measured, min), max);
+
+    if (clamped !== lastHeight) {
+      docEl.style.setProperty("--nav-height", `${clamped}px`);
+      lastHeight = clamped;
+    }
+  };
+
+  const scheduleMeasure = () => {
+    if (frameId) {
+      cancelAnimationFrame(frameId);
+    }
+    frameId = requestAnimationFrame(measureHeader);
+  };
+
+  window.addEventListener("resize", scheduleMeasure, { passive: true });
+  window.addEventListener("load", scheduleMeasure);
+  window.addEventListener("imhis-language-change", scheduleMeasure);
+  window.addEventListener("imhis-header-resize", scheduleMeasure);
+
+  document.addEventListener("DOMContentLoaded", () => {
+    scheduleMeasure();
+    const header = document.querySelector(".site-header") || document.querySelector("header");
+    if (header && "ResizeObserver" in window) {
+      const observer = new ResizeObserver(scheduleMeasure);
+      observer.observe(header);
+    }
+  });
+
+  scheduleMeasure();
+})();

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -14,6 +14,8 @@
   --color-text-light: #475569;
   --radius-large: 1.5rem;
   --nav-height: 80px;
+  --nav-height-min: 64px;
+  --nav-height-max: 144px;
 }
 
 body {
@@ -26,8 +28,15 @@ body {
 }
 
 html {
-  scroll-padding-top: var(--nav-height);
-  scroll-padding-top: calc(var(--nav-height) + env(safe-area-inset-top));
+  scroll-padding-top: clamp(
+    var(--nav-height-min),
+    var(--nav-height, 80px),
+    var(--nav-height-max)
+  );
+  scroll-padding-top: calc(
+    clamp(var(--nav-height-min), var(--nav-height, 80px), var(--nav-height-max)) +
+      env(safe-area-inset-top)
+  );
 }
 
 a {
@@ -50,7 +59,11 @@ a {
   background: var(--color-section);
   border-bottom: 1px solid var(--color-border);
   box-shadow: none;
-  min-height: var(--nav-height);
+  min-height: clamp(
+    var(--nav-height-min),
+    var(--nav-height, 80px),
+    var(--nav-height-max)
+  );
   display: flex;
   align-items: center;
 }
@@ -60,7 +73,11 @@ a {
   max-width: 1200px;
   margin: 0 auto;
   padding: 0 20px;
-  min-height: var(--nav-height);
+  min-height: clamp(
+    var(--nav-height-min),
+    var(--nav-height, 80px),
+    var(--nav-height-max)
+  );
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -229,7 +246,11 @@ a {
 @media (max-width: 767px) {
   .site-header .header-inner {
     padding: 0 1rem;
-    min-height: var(--nav-height);
+    min-height: clamp(
+      var(--nav-height-min),
+      var(--nav-height, 80px),
+      var(--nav-height-max)
+    );
     gap: 0.9rem;
   }
 


### PR DESCRIPTION
## Summary
- clamp the header height variables and scroll padding so the sticky header can no longer grow to fill the viewport
- rewrite the shared navigation script to unify the burger menu behaviour, close logic, and aria labels across all pages
- throttle and clamp header height measurements so anchor offsets stay consistent after menu interactions

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dc19e57de88326aedefcef5cc391d4