### PR TITLE
Reduce global header height

### DIFF
--- a/scripts/main.min.js
+++ b/scripts/main.min.js
@@ -308,8 +308,8 @@
       return;
     }
 
-    const min = parseCssValue("--nav-height-min", 64);
-    const max = parseCssValue("--nav-height-max", 144);
+    const min = parseCssValue("--nav-height-min", 56);
+    const max = parseCssValue("--nav-height-max", 96);
     const clamped = Math.min(Math.max(measured, min), max);
 
     if (clamped !== lastHeight) {

--- a/style.css
+++ b/style.css
@@ -12,7 +12,9 @@
         --color-bg: #f9fafb; /* sehr helles Grau als Hintergrund */
         --color-text: #1e293b; /* dunkler Grauton für Lesetext */
         --radius-large: 1.5rem;
-        --nav-height: 80px;
+        --nav-height: 60px;
+        --nav-height-min: 56px;
+        --nav-height-max: 96px;
       }
 
       /* Grundaufbau */
@@ -98,7 +100,7 @@
       @media (max-width: 767px) {
         .nav-links {
           position: absolute;
-          top: var(--nav-height, 80px);
+          top: var(--nav-height, 60px);
           left: 1rem;
           right: 1rem;
           flex-direction: column;

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -13,9 +13,9 @@
   --color-text: #1e293b; /* dunkler Grauton für Lesetext */
   --color-text-light: #475569;
   --radius-large: 1.5rem;
-  --nav-height: 80px;
-  --nav-height-min: 64px;
-  --nav-height-max: 144px;
+  --nav-height: 60px;
+  --nav-height-min: 56px;
+  --nav-height-max: 96px;
 }
 
 body {
@@ -30,11 +30,11 @@ body {
 html {
   scroll-padding-top: clamp(
     var(--nav-height-min),
-    var(--nav-height, 80px),
+    var(--nav-height, 60px),
     var(--nav-height-max)
   );
   scroll-padding-top: calc(
-    clamp(var(--nav-height-min), var(--nav-height, 80px), var(--nav-height-max)) +
+    clamp(var(--nav-height-min), var(--nav-height, 60px), var(--nav-height-max)) +
       env(safe-area-inset-top)
   );
 }
@@ -61,7 +61,7 @@ a {
   box-shadow: none;
   min-height: clamp(
     var(--nav-height-min),
-    var(--nav-height, 80px),
+    var(--nav-height, 60px),
     var(--nav-height-max)
   );
   display: flex;
@@ -75,7 +75,7 @@ a {
   padding: 0 20px;
   min-height: clamp(
     var(--nav-height-min),
-    var(--nav-height, 80px),
+    var(--nav-height, 60px),
     var(--nav-height-max)
   );
   display: flex;
@@ -248,7 +248,7 @@ a {
     padding: 0 1rem;
     min-height: clamp(
       var(--nav-height-min),
-      var(--nav-height, 80px),
+      var(--nav-height, 60px),
       var(--nav-height-max)
     );
     gap: 0.9rem;

--- a/styles/main.min.css
+++ b/styles/main.min.css
@@ -61,4 +61,4 @@
   }
 }
 
-@media(max-width:767px){.nav-links{position:absolute;top:var(--nav-height,80px);left:1rem;right:1rem;flex-direction:column;align-items:flex-start;gap:1.25rem;padding:1.25rem;background:#fff;border-radius:var(--radius-large,1.5rem);box-shadow:0 8px 24px rgba(15,23,42,.1);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .3s ease,opacity .3s ease}.nav-links.open{transform:translateY(0);opacity:1;pointer-events:auto}.nav-links li{width:100%}.nav-links a{width:100%;display:block;font-size:1.1rem}}
+@media(max-width:767px){.nav-links{position:absolute;top:var(--nav-height,60px);left:1rem;right:1rem;flex-direction:column;align-items:flex-start;gap:1.25rem;padding:1.25rem;background:#fff;border-radius:var(--radius-large,1.5rem);box-shadow:0 8px 24px rgba(15,23,42,.1);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .3s ease,opacity .3s ease}.nav-links.open{transform:translateY(0);opacity:1;pointer-events:auto}.nav-links li{width:100%}.nav-links a{width:100%;display:block;font-size:1.1rem}}


### PR DESCRIPTION
## Summary
- reduce the shared navigation height variables to align with the logo size and tighten top/bottom spacing across all pages
- update responsive navigation offsets and the resize helper to honor the new fixed header height limits

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68dc1d78c9f48326b073154703569523