### PR TITLE
Stop clamping measured header height

### DIFF
--- a/scripts/main.min.js
+++ b/scripts/main.min.js
@@ -310,11 +310,14 @@
 
     const min = parseCssValue("--nav-height-min", 56);
     const max = parseCssValue("--nav-height-max", 96);
-    const clamped = Math.min(Math.max(measured, min), max);
+    const adjusted = Math.max(measured, min);
 
-    if (clamped !== lastHeight) {
-      docEl.style.setProperty("--nav-height", `${clamped}px`);
-      lastHeight = clamped;
+    if (adjusted !== lastHeight) {
+      docEl.style.setProperty("--nav-height", `${adjusted}px`);
+      if (adjusted > max) {
+        docEl.style.setProperty("--nav-height-max", `${adjusted}px`);
+      }
+      lastHeight = adjusted;
     }
   };
 


### PR DESCRIPTION
## Summary
- allow the measured nav height to exceed the configured maximum value
- raise the `--nav-height-max` CSS variable when the measured header grows taller than its default

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc2048bfc88326a3c4091a1e09f8bc