### PR TITLE
Fix timeline layout on mobile

### DIFF
--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -569,21 +569,31 @@
     }
     /* Responsive Anpassungen */
     @media (max-width: 768px) {
+      #timeline .timeline-line {
+        left: 28px;
+        transform: none;
+      }
       #timeline .timeline::before {
-        left: 20px;
+        left: 28px;
       }
       #timeline .timeline-item {
         width: 100%;
-        padding-left: 40px;
-        padding-right: 20px;
+        padding-left: 72px;
+        padding-right: 24px;
         text-align: left !important;
       }
       #timeline .timeline-item:nth-child(odd), #timeline .timeline-item:nth-child(even) {
         left: 0;
       }
       #timeline .timeline-item::before {
-        left: 20px;
+        left: 28px;
         margin-left: 0;
+      }
+      #timeline .timeline-item::after {
+        left: 28px;
+        right: auto;
+        width: 24px;
+        transform-origin: 0% 50%;
       }
     }
 


### PR DESCRIPTION
## Summary
- reposition the timeline axis and items on small screens to prevent overlap with text
- adjust mobile padding and connector widths so content sits beside the axis without collisions

## Testing
- Manually verified in a mobile viewport


------
https://chatgpt.com/codex/tasks/task_e_68dc20c88ac083268eef6e4b9b22fbdf