### PR TITLE
Expose reusable navigation controller

### DIFF
--- a/index.html
+++ b/index.html
@@ -580,11 +580,71 @@
       </section>
 
    <script>
-      function toggleMenu() {
-        const overlay = document.getElementById('mobileOverlay');
-        overlay.classList.toggle('open');
+    (() => {
+      const navToggle = document.querySelector('.nav-toggle');
+      const navLinks = document.querySelector('.nav-links');
+      if (!navToggle || !navLinks) {
+        return;
       }
-    </script>
+
+      const overlay = document.getElementById('mobileOverlay');
+
+      const syncOverlay = (isOpen) => {
+        if (!overlay) {
+          return;
+        }
+        overlay.classList.toggle('open', isOpen);
+        if ('hidden' in overlay) {
+          overlay.hidden = !isOpen;
+        }
+      };
+
+      const wireController = (controller) => {
+        const handleToggleClick = (event) => {
+          event.preventDefault();
+          event.imhisNavHandled = true;
+          controller.toggle({ reason: 'page-nav-toggle' });
+        };
+
+        const handleLinkClick = (event) => {
+          const target = event.target instanceof Element ? event.target.closest('a') : null;
+          if (!target) {
+            return;
+          }
+          event.imhisNavHandled = true;
+          controller.close({ reason: 'page-nav-link' });
+        };
+
+        navToggle.addEventListener('click', handleToggleClick);
+        navLinks.addEventListener('click', handleLinkClick);
+
+        syncOverlay(controller.isOpen());
+      };
+
+      const handleNavChange = (event) => {
+        if (!event.detail) {
+          return;
+        }
+        syncOverlay(Boolean(event.detail.open));
+      };
+
+      window.addEventListener('imhis-navigation-change', handleNavChange);
+
+      if (window.IMHISNavigation) {
+        wireController(window.IMHISNavigation);
+      } else {
+        window.addEventListener(
+          'imhis-navigation-ready',
+          (event) => {
+            if (event.detail) {
+              wireController(event.detail);
+            }
+          },
+          { once: true }
+        );
+      }
+    })();
+   </script>
    <!-- Produkt Pitch – neue Sektion für den Produkt Pitch: Licht in die Black Box -->
    <section aria-labelledby="pitch-title" class="section instrument-pro" id="pitch">
     <div class="instrument-outer">

--- a/scripts/main.min.js
+++ b/scripts/main.min.js
@@ -93,6 +93,23 @@
 
   const mediaQuery = window.matchMedia("(min-width: 768px)");
   let abortController;
+  let navController;
+
+  const normalizeOptions = (input, fallbackReason) => {
+    if (typeof input === "string") {
+      return { reason: input, silent: false };
+    }
+    if (input && typeof input === "object") {
+      return {
+        reason: input.reason ?? fallbackReason,
+        silent: Boolean(input.silent),
+      };
+    }
+    if (fallbackReason) {
+      return { reason: fallbackReason, silent: false };
+    }
+    return { silent: false };
+  };
 
   const updateToggleLabel = (isOpen) => {
     const suffix = document.documentElement.lang === "en" ? "En" : "De";
@@ -107,7 +124,23 @@
     window.dispatchEvent(new Event("imhis-header-resize"));
   };
 
-  const closeMenu = () => {
+  const notifyNavChange = (isOpen, reason) => {
+    window.dispatchEvent(
+      new CustomEvent("imhis-navigation-change", {
+        detail: {
+          open: isOpen,
+          reason,
+          controller: navController ?? null,
+        },
+      })
+    );
+  };
+
+  const isMenuOpen = () => navLinks.classList.contains("open");
+
+  const closeMenu = (input) => {
+    const options = normalizeOptions(input, "internal");
+    const wasOpen = isMenuOpen();
     navLinks.classList.remove("open");
     navLinks.hidden = !mediaQuery.matches;
     navToggle.classList.remove("open");
@@ -118,6 +151,9 @@
       abortController = undefined;
     }
     dispatchHeaderResize();
+    if (wasOpen && !options.silent) {
+      notifyNavChange(false, options.reason ?? "internal");
+    }
   };
 
   const handleOutsideClick = (event) => {
@@ -125,16 +161,21 @@
     if (target && (navLinks.contains(target) || navToggle.contains(target))) {
       return;
     }
-    closeMenu();
+    closeMenu("outside-click");
   };
 
   const handleEscape = (event) => {
     if (event.key === "Escape") {
-      closeMenu();
+      closeMenu("escape");
     }
   };
 
-  const openMenu = () => {
+  const openMenu = (input) => {
+    const options = normalizeOptions(input, "internal");
+    if (isMenuOpen()) {
+      navLinks.hidden = false;
+      return;
+    }
     navLinks.hidden = false;
     navLinks.classList.add("open");
     navToggle.classList.add("open");
@@ -149,13 +190,16 @@
       signal: abortController.signal,
     });
     dispatchHeaderResize();
+    if (!options.silent) {
+      notifyNavChange(true, options.reason ?? "internal");
+    }
   };
 
-  const toggleMenu = () => {
-    if (navLinks.classList.contains("open")) {
-      closeMenu();
+  const toggleMenu = (input) => {
+    if (isMenuOpen()) {
+      closeMenu(input);
     } else {
-      openMenu();
+      openMenu(input);
     }
   };
 
@@ -163,22 +207,61 @@
     if (event.matches) {
       navLinks.hidden = false;
     }
-    closeMenu();
+    const wasOpen = isMenuOpen();
+    closeMenu({ reason: "media-query", silent: !wasOpen });
     navLinks.hidden = !event.matches;
   };
 
+  navController = Object.freeze({
+    open: (options) => openMenu(options),
+    close: (options) => closeMenu(options),
+    toggle: (options) => toggleMenu(options),
+    isOpen: () => isMenuOpen(),
+  });
+
+  window.IMHISNavigation = navController;
+  window.dispatchEvent(
+    new CustomEvent("imhis-navigation-ready", {
+      detail: navController,
+    })
+  );
+
   mediaQuery.addEventListener("change", handleMediaChange);
 
-  navToggle.addEventListener("click", toggleMenu);
+  navToggle.addEventListener("click", (event) => {
+    if (event.imhisNavHandled) {
+      return;
+    }
+    toggleMenu();
+  });
   navLinks.addEventListener("click", (event) => {
+    if (event.imhisNavHandled) {
+      return;
+    }
     const target = event.target instanceof Element ? event.target : null;
     if (target && target.closest("a")) {
-      closeMenu();
+      closeMenu("nav-link");
     }
   });
 
   window.addEventListener("imhis-language-change", () => {
-    updateToggleLabel(navToggle.classList.contains("open"));
+    updateToggleLabel(isMenuOpen());
+  });
+
+  window.addEventListener("imhis-navigation-request", (event) => {
+    const detail = event.detail || {};
+    const action = detail.action;
+    const payload = {
+      reason: detail.reason ?? "external-request",
+      silent: detail.silent === true,
+    };
+    if (action === "open") {
+      openMenu(payload);
+    } else if (action === "close") {
+      closeMenu(payload);
+    } else if (action === "toggle") {
+      toggleMenu(payload);
+    }
   });
 
   updateToggleLabel(false);


### PR DESCRIPTION
## Summary
- expose the global navigation controller as `window.IMHISNavigation`, fire ready/change events, and accept external open/close/toggle requests
- update the landing page burger-menu helper to call the shared controller instead of toggling state directly, marking events as handled and keeping an optional overlay in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc1dbd2fa483269b2e868f114d5d29