### PR TITLE
Fix timeline layout on mobile

### DIFF
--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -71,6 +71,7 @@
       max-width: 1200px;
       margin: 0 auto;
       padding: 20px;
+      box-sizing: border-box;
     }
 
     /* Globale Button‑Klassen für ein konsistentes Erscheinungsbild */
@@ -487,10 +488,10 @@
       z-index: 3;
     }
     #timeline .timeline-item:nth-child(odd)::before {
-      right: -13px;
+      right: -10px;
     }
     #timeline .timeline-item:nth-child(even)::before {
-      left: -13px;
+      left: -10px;
     }
     /* Hover‑Effekt für Timeline‑Punkte */
     #timeline .timeline-item:hover::before {
@@ -587,7 +588,7 @@
       }
       #timeline .timeline-item::before {
         left: 28px;
-        margin-left: 0;
+        margin-left: -10px;
       }
       #timeline .timeline-item::after {
         left: 28px;


### PR DESCRIPTION
## Summary
- prevent the timeline container padding from creating horizontal overflow on small screens
- center the career timeline markers on the vertical axis across breakpoints

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc2280dd8c8326b41219b96fd43c51