### PR TITLE
Adjust mobile header layout

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -245,19 +245,43 @@ a {
 
 @media (max-width: 767px) {
   .site-header .header-inner {
+    width: 100%;
     padding: 0 1rem;
     min-height: clamp(
       var(--nav-height-min),
       var(--nav-height, 60px),
       var(--nav-height-max)
     );
-    gap: 0.9rem;
+    gap: 0.75rem;
+    flex-wrap: nowrap;
+  }
+
+  .site-header .logo {
+    flex: 0 0 auto;
+  }
+
+  .site-header .actions {
+    order: 1;
+    flex: 0 0 auto;
+    width: auto;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .site-header .actions .lang-switcher {
+    flex: 0 0 auto;
+    justify-content: center;
+  }
+
+  .site-header .actions .btn {
+    display: none;
   }
 
   .site-header .nav {
     order: 2;
-    width: 100%;
-    justify-content: space-between;
+    flex: 1 1 auto;
+    justify-content: flex-end;
+    width: auto;
   }
 
   .nav-toggle {
@@ -300,22 +324,6 @@ a {
     font-size: 1.05rem;
   }
 
-  .site-header .actions {
-    order: 3;
-    width: 100%;
-    justify-content: stretch;
-    gap: 0.65rem;
-  }
-
-  .site-header .actions .lang-switcher {
-    flex: 1 1 100%;
-    justify-content: center;
-  }
-
-  .site-header .actions .btn {
-    flex: 1 1 auto;
-    justify-content: center;
-  }
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- align the mobile header layout so the burger toggle stays level with the logo and the language switcher sits in between
- hide the contact CTA on small screens to keep the compact header row and rely on the drawer for navigation

## Testing
- no automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc235d9a3483268ea2aaf487928135