### PR TITLE
Fix header height

### DIFF
--- a/scripts/main.min.js
+++ b/scripts/main.min.js
@@ -393,13 +393,10 @@
 
     const min = parseCssValue("--nav-height-min", 56);
     const max = parseCssValue("--nav-height-max", 96);
-    const adjusted = Math.max(measured, min);
+    const adjusted = Math.min(Math.max(measured, min), max);
 
     if (adjusted !== lastHeight) {
       docEl.style.setProperty("--nav-height", `${adjusted}px`);
-      if (adjusted > max) {
-        docEl.style.setProperty("--nav-height-max", `${adjusted}px`);
-      }
       lastHeight = adjusted;
     }
   };

--- a/style.css
+++ b/style.css
@@ -12,9 +12,13 @@
         --color-bg: #f9fafb; /* sehr helles Grau als Hintergrund */
         --color-text: #1e293b; /* dunkler Grauton für Lesetext */
         --radius-large: 1.5rem;
-        --nav-height: 60px;
         --nav-height-min: 56px;
         --nav-height-max: 96px;
+        --nav-height: clamp(
+          var(--nav-height-min),
+          calc(6vw + 16px),
+          var(--nav-height-max)
+        );
       }
 
       /* Grundaufbau */
@@ -45,6 +49,8 @@
         backdrop-filter: saturate(180%) blur(12px);
         background: rgba(255, 255, 255, 0.8);
         box-shadow: 0 2px 8px rgba(15, 23, 42, 0.05);
+        height: var(--nav-height);
+        min-height: var(--nav-height);
       }
 
       .navbar {
@@ -100,7 +106,7 @@
       @media (max-width: 767px) {
         .nav-links {
           position: absolute;
-          top: var(--nav-height, 60px);
+          top: var(--nav-height);
           left: 1rem;
           right: 1rem;
           flex-direction: column;

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -13,9 +13,13 @@
   --color-text: #1e293b; /* dunkler Grauton für Lesetext */
   --color-text-light: #475569;
   --radius-large: 1.5rem;
-  --nav-height: 60px;
   --nav-height-min: 56px;
   --nav-height-max: 96px;
+  --nav-height: clamp(
+    var(--nav-height-min),
+    calc(6vw + 16px),
+    var(--nav-height-max)
+  );
 }
 
 body {
@@ -28,15 +32,8 @@ body {
 }
 
 html {
-  scroll-padding-top: clamp(
-    var(--nav-height-min),
-    var(--nav-height, 60px),
-    var(--nav-height-max)
-  );
-  scroll-padding-top: calc(
-    clamp(var(--nav-height-min), var(--nav-height, 60px), var(--nav-height-max)) +
-      env(safe-area-inset-top)
-  );
+  scroll-padding-top: var(--nav-height);
+  scroll-padding-top: calc(var(--nav-height) + env(safe-area-inset-top));
 }
 
 a {
@@ -59,11 +56,8 @@ a {
   background: var(--color-section);
   border-bottom: 1px solid var(--color-border);
   box-shadow: none;
-  min-height: clamp(
-    var(--nav-height-min),
-    var(--nav-height, 60px),
-    var(--nav-height-max)
-  );
+  height: var(--nav-height);
+  min-height: var(--nav-height);
   display: flex;
   align-items: center;
 }
@@ -73,11 +67,8 @@ a {
   max-width: 1200px;
   margin: 0 auto;
   padding: 0 20px;
-  min-height: clamp(
-    var(--nav-height-min),
-    var(--nav-height, 60px),
-    var(--nav-height-max)
-  );
+  height: var(--nav-height);
+  min-height: var(--nav-height);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -247,11 +238,8 @@ a {
   .site-header .header-inner {
     width: 100%;
     padding: 0 1rem;
-    min-height: clamp(
-      var(--nav-height-min),
-      var(--nav-height, 60px),
-      var(--nav-height-max)
-    );
+    height: var(--nav-height);
+    min-height: var(--nav-height);
     gap: 0.75rem;
     flex-wrap: nowrap;
   }

--- a/styles/main.min.css
+++ b/styles/main.min.css
@@ -61,4 +61,4 @@
   }
 }
 
-@media(max-width:767px){.nav-links{position:absolute;top:var(--nav-height,60px);left:1rem;right:1rem;flex-direction:column;align-items:flex-start;gap:1.25rem;padding:1.25rem;background:#fff;border-radius:var(--radius-large,1.5rem);box-shadow:0 8px 24px rgba(15,23,42,.1);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .3s ease,opacity .3s ease}.nav-links.open{transform:translateY(0);opacity:1;pointer-events:auto}.nav-links li{width:100%}.nav-links a{width:100%;display:block;font-size:1.1rem}}
+@media(max-width:767px){.nav-links{position:absolute;top:var(--nav-height);left:1rem;right:1rem;flex-direction:column;align-items:flex-start;gap:1.25rem;padding:1.25rem;background:#fff;border-radius:var(--radius-large,1.5rem);box-shadow:0 8px 24px rgba(15,23,42,.1);transform:translateY(-10px);opacity:0;pointer-events:none;transition:transform .3s ease,opacity .3s ease}.nav-links.open{transform:translateY(0);opacity:1;pointer-events:auto}.nav-links li{width:100%}.nav-links a{width:100%;display:block;font-size:1.1rem}}


### PR DESCRIPTION
## Summary
- clamp the navigation height CSS variable so the sticky header keeps a consistent size across pages
- update the mobile navigation dropdown positioning to use the refined height variable
- clamp the measured header height in the JavaScript observer to avoid inflating the CSS custom properties

## Testing
- ⚠️ Tests not run (static site; no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68dc2548516c83268008a8452cc6b1f3