### PR TITLE
Adjust mobile menu dropdown width

### DIFF
--- a/style.css
+++ b/style.css
@@ -107,12 +107,13 @@
         .nav-links {
           position: absolute;
           top: var(--nav-height);
-          left: 1rem;
           right: 1rem;
+          left: auto;
+          width: fit-content;
           flex-direction: column;
-          align-items: flex-start;
-          gap: 1.25rem;
-          padding: 1.25rem;
+          align-items: stretch;
+          gap: 1rem;
+          padding: 0.75rem 1rem;
           background: #fff;
           border-radius: var(--radius-large, 1.5rem);
           box-shadow: 0 8px 24px rgba(15, 23, 42, 0.1);
@@ -128,14 +129,10 @@
           pointer-events: auto;
         }
 
-        .nav-links li {
-          width: 100%;
-        }
-
         .nav-links a {
-          width: 100%;
           display: block;
           font-size: 1.1rem;
+          padding: 0.35rem 0;
         }
 
         .nav-links .btn {


### PR DESCRIPTION
## Summary
- restrict the mobile navigation dropdown to the width of its links so the burger menu panel no longer spans the full viewport
- tweak spacing and padding for the compact dropdown layout

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc281062ec832690f4711ab3cd0eb3