### PR TITLE
Fix mobile body padding overflow

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -29,11 +29,15 @@ body {
   color: var(--color-text);
   background: var(--color-bg);
   line-height: 1.6;
+  padding: 0;
+  border-top: none;
+  overflow-x: hidden;
 }
 
 html {
   scroll-padding-top: var(--nav-height);
   scroll-padding-top: calc(var(--nav-height) + env(safe-area-inset-top));
+  overflow-x: hidden;
 }
 
 a {


### PR DESCRIPTION
## Summary
- remove the global body padding/border that introduced a right-side gap on mobile
- hide horizontal overflow on the html and body elements to keep the layout within the viewport

## Testing
- not run (static CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68dc2dba7ff0832685bc10b506433dfd