### PR TITLE
Add SEO metadata to Florian Eisold profile page

### DIFF
--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -3,7 +3,71 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Florian Eisold – Profil</title>
+  <title>Dr. Florian Eisold – Arzt, Ökonom &amp; Jurist im digitalen Gesundheitswesen</title>
+  <meta name="description" content="Lernen Sie Dr. Florian Eisold kennen – Arzt, Ökonom und Jurist, der mit IMHIS digitale Gesundheits- und Krankenhausinformationssysteme strategisch weiterentwickelt."/>
+  <meta name="keywords" content="Dr. Florian Eisold, Medizincontroller, IMHIS, digitales Gesundheitswesen, Krankenhausinformatik, Medizinrecht, Gesundheitsökonomie"/>
+  <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1"/>
+  <meta name="author" content="Dr. Florian Richard Eisold"/>
+  <meta name="theme-color" content="#0f172a"/>
+  <meta name="color-scheme" content="light dark"/>
+  <link rel="canonical" href="https://imhis.de/florian-eisold.html"/>
+  <link rel="author" href="https://imhis.de/florian-eisold.html"/>
+  <link rel="sitemap" type="application/xml" href="/sitemap.xml"/>
+  <meta property="og:title" content="Dr. Florian Eisold – Arzt, Ökonom &amp; Jurist"/>
+  <meta property="og:description" content="Profil von Dr. Florian Eisold: Interdisziplinärer Experte für digitale Gesundheitsstrategien, IMHIS-Entwickler und Medizincontroller."/>
+  <meta property="og:url" content="https://imhis.de/florian-eisold.html"/>
+  <meta property="og:type" content="profile"/>
+  <meta property="og:site_name" content="IMHIS"/>
+  <meta property="og:locale" content="de_DE"/>
+  <meta property="og:image" content="https://imhis.de/assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg"/>
+  <meta property="og:image:alt" content="Porträt von Dr. Florian Richard Eisold"/>
+  <meta property="profile:first_name" content="Florian"/>
+  <meta property="profile:last_name" content="Eisold"/>
+  <meta property="profile:username" content="florian-eisold"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Dr. Florian Eisold – Arzt, Ökonom &amp; Jurist"/>
+  <meta name="twitter:description" content="Interdisziplinäre Expertise für digitale Gesundheitssysteme: Arzt, Ökonom, Jurist und Entwickler des IMHIS-Analyseinstrumentes."/>
+  <meta name="twitter:image" content="https://imhis.de/assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg"/>
+  <meta name="twitter:image:alt" content="Porträt von Dr. Florian Richard Eisold"/>
+  <meta name="twitter:creator" content="@FlorianEisold"/>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "Dr. Florian Richard Eisold",
+      "url": "https://imhis.de/florian-eisold.html",
+      "jobTitle": [
+        "Medizincontroller",
+        "Arzt",
+        "Gesundheitsökonom"
+      ],
+      "worksFor": {
+        "@type": "Organization",
+        "name": "Bundeswehrzentralkrankenhaus Koblenz"
+      },
+      "alumniOf": [
+        {
+          "@type": "CollegeOrUniversity",
+          "name": "Ludwig-Maximilians-Universität München"
+        },
+        {
+          "@type": "CollegeOrUniversity",
+          "name": "Universität Münster"
+        }
+      ],
+      "sameAs": [
+        "https://www.linkedin.com/in/dr-med-florian-r-eisold-b-sc-ll-m-7a4a08145/"
+      ],
+      "image": "https://imhis.de/assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg",
+      "description": "Dr. Florian Eisold verbindet Medizin, Ökonomie und Recht, um digitale Gesundheitslösungen messbar erfolgreich zu machen.",
+      "knowsAbout": [
+        "Krankenhausinformationssysteme",
+        "Medizinrecht",
+        "Gesundheitsökonomie",
+        "Digitale Transformation im Gesundheitswesen"
+      ]
+    }
+  </script>
   <!-- Einbindung der Inter‑Schrift über Google Fonts für konsistente Typografie -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -757,10 +821,11 @@
     <div class="section-frame hero-card">
       <!-- Platzhalter‑Bild, ersetze durch echtes Porträt bei Live‑Einsatz -->
       <img
-        alt="Dr. Florian Eisold"
-        data-alt-en="Dr. Florian Eisold"
+        alt="Porträt von Dr. Florian Richard Eisold"
+        data-alt-en="Portrait of Dr. Florian Richard Eisold"
         decoding="async"
-        loading="lazy"
+        loading="eager"
+        fetchpriority="high"
         src="assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg"
         width="200"
         height="200"


### PR DESCRIPTION
## Summary
- add comprehensive SEO meta tags and social previews to florian-eisold.html
- embed structured data for the Florian Eisold profile page
- improve hero image loading hints and alt text for better discoverability

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dc37f404fc8326aa76c24f780f5e8f