### PR TITLE
Align Florian hero portrait with about styling and keep mobile menu visible

### DIFF
--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -179,21 +179,46 @@
       padding: 80px 20px 60px;
     }
     #hero .hero-card {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 40px;
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: clamp(1.75rem, 5vw, 2.75rem);
       align-items: center;
     }
-    #hero .hero-card img {
-      width: 200px;
-      height: 200px;
+    #hero .hero-portrait {
+      position: relative;
+      margin: 0;
+      width: clamp(150px, 28vw, 190px);
+      aspect-ratio: 1 / 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    #hero .hero-portrait::before {
+      content: "";
+      position: absolute;
+      inset: -12%;
+      border-radius: 50%;
+      background: radial-gradient(
+        circle at 40% 35%,
+        rgba(37, 99, 235, 0.22),
+        rgba(37, 99, 235, 0)
+      );
+      filter: blur(18px);
+      z-index: 0;
+    }
+    #hero .hero-portrait img {
+      position: relative;
+      width: 100%;
+      height: 100%;
       border-radius: 50%;
       object-fit: cover;
-      border: 4px solid var(--color-accent);
+      object-position: top center;
+      box-shadow: 0 12px 32px rgba(15, 23, 42, 0.18);
+      z-index: 1;
     }
     #hero .hero-text {
-      flex: 1 1 350px;
       min-width: 280px;
+      max-width: 100%;
     }
     #hero .hero-text h1 {
       margin-top: 0;
@@ -235,15 +260,15 @@
     }
     @media (max-width: 768px) {
       #hero .hero-card {
+        grid-template-columns: 1fr;
         text-align: center;
-        padding: 30px;
+        padding: clamp(1.75rem, 6vw, 2.25rem);
       }
-      #hero .hero-card img {
-        margin-left: auto;
-        margin-right: auto;
+      #hero .hero-portrait {
+        margin: 0 auto;
       }
       #hero .hero-text {
-        flex: 1 1 100%;
+        text-align: center;
       }
       #hero .hero-buttons {
         justify-content: center;
@@ -820,16 +845,18 @@
   <section id="hero">
     <div class="section-frame hero-card">
       <!-- Platzhalter‑Bild, ersetze durch echtes Porträt bei Live‑Einsatz -->
-      <img
-        alt="Porträt von Dr. Florian Richard Eisold"
-        data-alt-en="Portrait of Dr. Florian Richard Eisold"
-        decoding="async"
-        loading="eager"
-        fetchpriority="high"
-        src="assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg"
-        width="200"
-        height="200"
-      />
+      <figure class="hero-portrait">
+        <img
+          alt="Porträt von Dr. Florian Richard Eisold"
+          data-alt-en="Portrait of Dr. Florian Richard Eisold"
+          decoding="async"
+          loading="eager"
+          fetchpriority="high"
+          src="assets/c3535c5e-985e-4aff-979a-1de31ddb601c.jpg"
+          width="200"
+          height="200"
+        />
+      </figure>
       <div class="hero-text">
         <p class="eyebrow">
           <span class="lang lang-de">Profil</span>

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -278,12 +278,12 @@ a {
   }
 
   .site-header .actions {
-    order: 2;
+    order: 3;
     flex: 0 0 auto;
     width: auto;
     gap: 0.5rem;
     align-items: center;
-    margin-left: auto;
+    margin-left: 0;
     display: inline-flex;
     justify-content: flex-end;
   }
@@ -298,10 +298,12 @@ a {
   }
 
   .site-header .nav {
-    order: 3;
+    order: 2;
     flex: 0 0 auto;
     justify-content: flex-end;
     width: auto;
+    margin-left: auto;
+    min-width: 44px;
   }
 
   .nav-toggle {


### PR DESCRIPTION
## Summary
- restyle the Florian hero portrait to reuse the glowing circular treatment from the about section and update the markup accordingly
- tweak the global mobile header layout so the burger toggle always stays visible across all pages

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68dc38fe77a883269c7f9cc642990ea9