### PR TITLE
Improve mobile timeline layout

### DIFF
--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -724,14 +724,24 @@
       margin-bottom: 8px;
       font-size: 1.1rem;
       color: var(--color-text);
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
     #timeline .timeline-content p {
       margin: 0;
       font-size: 0.92rem;
       color: var(--color-text-light);
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
     /* Responsive Anpassungen */
     @media (max-width: 768px) {
+      #timeline .timeline {
+        width: 100%;
+        margin: 0;
+        padding-left: 0;
+        padding-right: 0;
+      }
       #timeline .timeline-line {
         left: 28px;
         transform: none;
@@ -741,8 +751,8 @@
       }
       #timeline .timeline-item {
         width: 100%;
-        padding-left: 72px;
-        padding-right: 24px;
+        padding-left: 64px;
+        padding-right: 16px;
         text-align: left !important;
       }
       #timeline .timeline-item:nth-child(odd), #timeline .timeline-item:nth-child(even) {


### PR DESCRIPTION
## Summary
- allow the career timeline text to wrap on small screens
- align the mobile timeline column to the left and tighten padding for a cleaner layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc3ac5d148832697da807cf766eb97