### PR TITLE
Align mobile timeline markers

### DIFF
--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -768,17 +768,18 @@
         transform: translate(-50%, -50%) scale(1);
       }
       #timeline .timeline-item::after {
-        left: 28px;
-        right: auto;
-        top: var(--marker-offset, 24px);
-        width: 32px;
-        transform-origin: 0% 50%;
+        content: none;
       }
       #timeline .timeline-item:hover::before {
         transform: translate(-50%, -50%) scale(1.4);
       }
       #timeline .timeline-item.in-view::before {
         transform: translate(-50%, -50%) scale(1.5);
+      }
+      #timeline .timeline-date {
+        display: block;
+        margin-left: 0;
+        padding-left: 0;
       }
     }
 


### PR DESCRIPTION
## Summary
- remove horizontal connectors from mobile timeline entries
- ensure timeline markers stay centered on the vertical axis and dates stack neatly on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcbdc144b08326854123dd896c7ec4