### PR TITLE
Fix timeline marker centering

### DIFF
--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -614,7 +614,9 @@
     #timeline .timeline-item {
       position: relative;
       width: 50%;
-      padding: 20px 40px;
+      --timeline-padding-left: 40px;
+      --timeline-padding-right: 40px;
+      padding: 20px var(--timeline-padding-right) 20px var(--timeline-padding-left);
       box-sizing: border-box;
       opacity: 0;
       transform: translateY(40px);
@@ -650,10 +652,10 @@
       transform: translate(-50%, -50%) scale(1);
     }
     #timeline .timeline-item:nth-child(odd)::before {
-      left: 100%;
+      left: calc(100% + var(--timeline-padding-right));
     }
     #timeline .timeline-item:nth-child(even)::before {
-      left: 0;
+      left: calc(0% - var(--timeline-padding-left));
     }
     /* Hover‑Effekt für Timeline‑Punkte */
     #timeline .timeline-item:hover::before {
@@ -681,11 +683,11 @@
       z-index: 1;
     }
     #timeline .timeline-item:nth-child(odd)::after {
-      right: 0;
+      right: calc(0% - var(--timeline-padding-right));
       transform-origin: 100% 50%;
     }
     #timeline .timeline-item:nth-child(even)::after {
-      left: 0;
+      left: calc(0% - var(--timeline-padding-left));
       transform-origin: 0% 50%;
     }
     #timeline .timeline-item.in-view::after {
@@ -751,8 +753,9 @@
       }
       #timeline .timeline-item {
         width: 100%;
-        padding-left: 64px;
-        padding-right: 16px;
+        --timeline-padding-left: 64px;
+        --timeline-padding-right: 16px;
+        padding: 20px var(--timeline-padding-right) 20px var(--timeline-padding-left);
         text-align: left !important;
       }
       #timeline .timeline-item:nth-child(odd), #timeline .timeline-item:nth-child(even) {


### PR DESCRIPTION
## Summary
- use CSS custom properties for timeline item padding so horizontal offsets are explicit
- align the marker and connector pseudo elements with the central timeline line across desktop and mobile breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcc1115394832693d148d8996642cf