### PR TITLE
Align timeline markers with center axis

### DIFF
--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -635,32 +635,53 @@
       left: 50%;
       text-align: left;
     }
-    #timeline .timeline-item::before {
-      content: '';
+    #timeline .timeline-item .timeline-marker {
+      --marker-scale: 1;
+      --marker-translate-x: -50%;
       position: absolute;
       top: var(--marker-offset, 28px);
-      /* Größerer Punkt mit doppelter Kontur für mehr Präsenz */
-      width: 20px;
-      height: 20px;
-      border-radius: 50%;
-      background: var(--color-accent);
-      border: 3px solid #fff;
-      box-shadow: 0 0 0 3px var(--color-accent);
-      transition: transform 0.3s ease, background 0.3s ease;
-      /* dot überlagert Verbindungslinie */
+      width: 28px;
+      height: 28px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transform: translate(var(--marker-translate-x), -50%) scale(var(--marker-scale));
+      transform-origin: center;
+      transition: transform 0.3s ease;
       z-index: 3;
-      transform: translate(-50%, -50%) scale(1);
+      filter: drop-shadow(0 6px 12px rgba(37, 99, 235, 0.25));
     }
-    #timeline .timeline-item:nth-child(odd)::before {
-      left: calc(100% + var(--timeline-padding-right));
+    #timeline .timeline-item .timeline-marker svg {
+      width: 100%;
+      height: 100%;
+      display: block;
     }
-    #timeline .timeline-item:nth-child(even)::before {
-      left: calc(0% - var(--timeline-padding-left));
+    #timeline .timeline-item .timeline-marker .marker-orbit {
+      fill: none;
+      stroke: rgba(37, 99, 235, 0.35);
+      stroke: color-mix(in srgb, var(--color-accent) 35%, transparent);
+      stroke-width: 3;
     }
-    /* Hover‑Effekt für Timeline‑Punkte */
-    #timeline .timeline-item:hover::before {
-      transform: translate(-50%, -50%) scale(1.4);
-      background: var(--color-accent-dark);
+    #timeline .timeline-item .timeline-marker .marker-ring {
+      fill: #fff;
+      stroke: var(--color-accent);
+      stroke-width: 3;
+    }
+    #timeline .timeline-item .timeline-marker .marker-core {
+      fill: var(--color-accent);
+      transition: fill 0.3s ease;
+    }
+    #timeline .timeline-item:nth-child(odd) .timeline-marker {
+      left: 100%;
+    }
+    #timeline .timeline-item:nth-child(even) .timeline-marker {
+      left: 0;
+    }
+    #timeline .timeline-item:hover .timeline-marker {
+      --marker-scale: 1.4;
+    }
+    #timeline .timeline-item:hover .timeline-marker .marker-core {
+      fill: var(--color-accent-dark);
     }
 
     /* Verbindungslinien zwischen Punkten und der Zentralachse */
@@ -695,9 +716,11 @@
     }
 
     /* Hover‑ähnlicher Effekt beim Scrollen: wenn Element im Viewport, wird der Punkt vergrößert und hervorgehoben */
-    #timeline .timeline-item.in-view::before {
-      transform: translate(-50%, -50%) scale(1.6);
-      background: var(--color-accent-dark);
+    #timeline .timeline-item.in-view .timeline-marker {
+      --marker-scale: 1.6;
+    }
+    #timeline .timeline-item.in-view .timeline-marker .marker-core {
+      fill: var(--color-accent-dark);
     }
     #timeline .timeline-item.in-view .timeline-date,
     #timeline .timeline-item.in-view h3 {
@@ -761,23 +784,29 @@
       #timeline .timeline-item:nth-child(odd), #timeline .timeline-item:nth-child(even) {
         left: 0;
       }
-      #timeline .timeline-item::before {
+      #timeline .timeline-item .timeline-marker {
         left: 28px;
+        --marker-translate-x: -50%;
         top: var(--marker-offset, 24px);
-        width: 14px;
-        height: 14px;
-        border-width: 2px;
-        box-shadow: 0 0 0 2px var(--color-accent);
-        transform: translate(-50%, -50%) scale(1);
+        width: 22px;
+        height: 22px;
+        filter: drop-shadow(0 4px 8px rgba(37, 99, 235, 0.2));
+      }
+      #timeline .timeline-item:nth-child(odd) .timeline-marker,
+      #timeline .timeline-item:nth-child(even) .timeline-marker {
+        left: 28px;
+      }
+      #timeline .timeline-item .timeline-marker .marker-ring {
+        stroke-width: 2.5;
       }
       #timeline .timeline-item::after {
         content: none;
       }
-      #timeline .timeline-item:hover::before {
-        transform: translate(-50%, -50%) scale(1.4);
+      #timeline .timeline-item:hover .timeline-marker {
+        --marker-scale: 1.3;
       }
-      #timeline .timeline-item.in-view::before {
-        transform: translate(-50%, -50%) scale(1.5);
+      #timeline .timeline-item.in-view .timeline-marker {
+        --marker-scale: 1.4;
       }
       #timeline .timeline-date {
         display: block;
@@ -919,6 +948,13 @@
         <div class="timeline-line"></div>
         <!-- Zukunft: geplanter PhD -->
         <div class="timeline-item">
+          <span class="timeline-marker" aria-hidden="true">
+            <svg viewBox="0 0 40 40" role="presentation" focusable="false">
+              <circle class="marker-orbit" cx="20" cy="20" r="19"></circle>
+              <circle class="marker-ring" cx="20" cy="20" r="13"></circle>
+              <circle class="marker-core" cx="20" cy="20" r="7"></circle>
+            </svg>
+          </span>
           <div class="timeline-date">
             <span class="lang lang-de">Oktober&nbsp;2025 – heute</span>
             <span class="lang lang-en" hidden>October&nbsp;2025 – today</span>
@@ -931,6 +967,13 @@
         </div>
         <!-- Gegenwart -->
         <div class="timeline-item">
+          <span class="timeline-marker" aria-hidden="true">
+            <svg viewBox="0 0 40 40" role="presentation" focusable="false">
+              <circle class="marker-orbit" cx="20" cy="20" r="19"></circle>
+              <circle class="marker-ring" cx="20" cy="20" r="13"></circle>
+              <circle class="marker-core" cx="20" cy="20" r="7"></circle>
+            </svg>
+          </span>
           <div class="timeline-date">
             <span class="lang lang-de">April&nbsp;2025 – heute</span>
             <span class="lang lang-en" hidden>April&nbsp;2025 – today</span>
@@ -946,6 +989,13 @@
         </div>
         <!-- LL.M. Abschluss -->
         <div class="timeline-item">
+          <span class="timeline-marker" aria-hidden="true">
+            <svg viewBox="0 0 40 40" role="presentation" focusable="false">
+              <circle class="marker-orbit" cx="20" cy="20" r="19"></circle>
+              <circle class="marker-ring" cx="20" cy="20" r="13"></circle>
+              <circle class="marker-core" cx="20" cy="20" r="7"></circle>
+            </svg>
+          </span>
           <div class="timeline-date">
             <span class="lang lang-de">Feb&nbsp;2023 – Apr&nbsp;2025</span>
             <span class="lang lang-en" hidden>Feb&nbsp;2023 – Apr&nbsp;2025</span>
@@ -958,6 +1008,13 @@
         </div>
         <!-- Assistenzarzt Erfahrungen -->
         <div class="timeline-item">
+          <span class="timeline-marker" aria-hidden="true">
+            <svg viewBox="0 0 40 40" role="presentation" focusable="false">
+              <circle class="marker-orbit" cx="20" cy="20" r="19"></circle>
+              <circle class="marker-ring" cx="20" cy="20" r="13"></circle>
+              <circle class="marker-core" cx="20" cy="20" r="7"></circle>
+            </svg>
+          </span>
           <div class="timeline-date">
             <span class="lang lang-de">Nov&nbsp;2022 – Apr&nbsp;2025</span>
             <span class="lang lang-en" hidden>Nov&nbsp;2022 – Apr&nbsp;2025</span>
@@ -973,6 +1030,13 @@
         </div>
         <!-- Promotion (Dr. med.) -->
         <div class="timeline-item">
+          <span class="timeline-marker" aria-hidden="true">
+            <svg viewBox="0 0 40 40" role="presentation" focusable="false">
+              <circle class="marker-orbit" cx="20" cy="20" r="19"></circle>
+              <circle class="marker-ring" cx="20" cy="20" r="13"></circle>
+              <circle class="marker-core" cx="20" cy="20" r="7"></circle>
+            </svg>
+          </span>
           <div class="timeline-date">
             <span class="lang lang-de">Aug&nbsp;2020 – Mai&nbsp;2025</span>
             <span class="lang lang-en" hidden>Aug&nbsp;2020 – May&nbsp;2025</span>
@@ -988,6 +1052,13 @@
         </div>
         <!-- Bachelor BWL Abschluss -->
         <div class="timeline-item">
+          <span class="timeline-marker" aria-hidden="true">
+            <svg viewBox="0 0 40 40" role="presentation" focusable="false">
+              <circle class="marker-orbit" cx="20" cy="20" r="19"></circle>
+              <circle class="marker-ring" cx="20" cy="20" r="13"></circle>
+              <circle class="marker-core" cx="20" cy="20" r="7"></circle>
+            </svg>
+          </span>
           <div class="timeline-date">
             <span class="lang lang-de">Nov&nbsp;2018 – Apr&nbsp;2022</span>
             <span class="lang lang-en" hidden>Nov&nbsp;2018 – Apr&nbsp;2022</span>
@@ -1000,6 +1071,13 @@
         </div>
         <!-- Studium Medizin Abschluss -->
         <div class="timeline-item">
+          <span class="timeline-marker" aria-hidden="true">
+            <svg viewBox="0 0 40 40" role="presentation" focusable="false">
+              <circle class="marker-orbit" cx="20" cy="20" r="19"></circle>
+              <circle class="marker-ring" cx="20" cy="20" r="13"></circle>
+              <circle class="marker-core" cx="20" cy="20" r="7"></circle>
+            </svg>
+          </span>
           <div class="timeline-date">
             <span class="lang lang-de">Nov&nbsp;2016 – Nov&nbsp;2022</span>
             <span class="lang lang-en" hidden>Nov&nbsp;2016 – Nov&nbsp;2022</span>
@@ -1015,6 +1093,13 @@
         </div>
         <!-- Beginn Sanitätsoffizier -->
         <div class="timeline-item">
+          <span class="timeline-marker" aria-hidden="true">
+            <svg viewBox="0 0 40 40" role="presentation" focusable="false">
+              <circle class="marker-orbit" cx="20" cy="20" r="19"></circle>
+              <circle class="marker-ring" cx="20" cy="20" r="13"></circle>
+              <circle class="marker-core" cx="20" cy="20" r="7"></circle>
+            </svg>
+          </span>
           <div class="timeline-date">
             <span class="lang lang-de">Jul&nbsp;2016</span>
             <span class="lang lang-en" hidden>Jul&nbsp;2016</span>
@@ -1027,6 +1112,13 @@
         </div>
         <!-- Abitur -->
         <div class="timeline-item">
+          <span class="timeline-marker" aria-hidden="true">
+            <svg viewBox="0 0 40 40" role="presentation" focusable="false">
+              <circle class="marker-orbit" cx="20" cy="20" r="19"></circle>
+              <circle class="marker-ring" cx="20" cy="20" r="13"></circle>
+              <circle class="marker-core" cx="20" cy="20" r="7"></circle>
+            </svg>
+          </span>
           <div class="timeline-date">
             <span class="lang lang-de">Jun&nbsp;2016</span>
             <span class="lang lang-en" hidden>Jun&nbsp;2016</span>


### PR DESCRIPTION
## Summary
- replace the unicode-style timeline bullets with inline SVG marker components to keep them centered on the axis
- add timeline marker styling for desktop and mobile views, including hover and in-view scaling
- update every timeline entry to render the new SVG marker element alongside the existing content
- normalize marker positioning so that SVG markers are mathematically centered on the timeline axis across breakpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcc40f29b883268e12358cf7763ed0