### PR TITLE
Align legal footer markup across static pages

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -697,48 +697,43 @@
         <span class="lang lang-en" hidden>Planning an analysis?</span>
       </a>
     </footer>
-    <footer class="legal-footer">
-      <div class="footer-brand">
-        <a aria-label="IMHIS Startseite" class="footer-logo-link" href="/index.html">
-          <img
-            alt="IMHIS Logo"
-            class="footer-logo"
-            data-alt-en="IMHIS logo"
-            decoding="async"
-            loading="lazy"
-            height="28"
-            src="assets/Logo_blau.svg"
-            width="120"
-          />
-        </a>
-        <a
-          aria-label="LinkedIn"
-          class="social-link"
-          href="https://www.linkedin.com/in/imhis/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg aria-hidden="true" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.356V9h3.414v1.561h.049c.476-.9 1.637-1.852 3.37-1.852 3.601 0 4.268 2.37 4.268 5.455v6.288zM5.337 7.433a2.062 2.062 0 1 1 0-4.125 2.062 2.062 0 0 1 0 4.125zm1.777 13.019H3.56V9h3.554v11.452zM22.225 0H1.771C.791 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0z"></path>
-          </svg>
-        </a>
-      </div>
-      <div class="legal-links">
-        <a href="/impressum.html">
-          <span class="lang lang-de">Impressum</span>
-          <span class="lang lang-en" hidden>Imprint</span>
-        </a>
-        <a href="/datenschutz.html">
-          <span class="lang lang-de">Datenschutz</span>
-          <span class="lang lang-en" hidden>Privacy Policy</span>
-        </a>
-      </div>
-      <p class="copyright">
-        © 2025 Dr. Florian Eisold. Inhalte urheberrechtlich
+  <!-- Rechtliches -->
+  <footer class="legal-footer">
+   <div class="footer-brand">
+    <a aria-label="IMHIS Startseite" class="footer-logo-link" href="/index.html">
+     <img alt="IMHIS Logo" class="footer-logo" data-alt-en="IMHIS logo" decoding="async" loading="lazy" height="28" src="assets/Logo_blau.svg" width="120"/>
+    </a>
+    <a aria-label="LinkedIn" class="social-link" href="https://www.linkedin.com/in/imhis/" rel="noopener noreferrer" target="_blank">
+     <svg aria-hidden="true" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.356V9h3.414v1.561h.049c.476-.9 1.637-1.852 3.37-1.852 3.601 0 4.268 2.37 4.268 5.455v6.288zM5.337 7.433a2.062 2.062 0 1 1 0-4.125 2.062 2.062 0 0 1 0 4.125zm1.777 13.019H3.56V9h3.554v11.452zM22.225 0H1.771C.791 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0z">
+      </path>
+     </svg>
+    </a>
+   </div>
+   <div class="legal-links">
+    <a href="/impressum.html">
+     <span class="lang lang-de">
+      Impressum
+     </span>
+     <span class="lang lang-en" hidden="">
+      Imprint
+     </span>
+    </a>
+    <a href="/datenschutz.html">
+     <span class="lang lang-de">
+      Datenschutz
+     </span>
+     <span class="lang lang-en" hidden="">
+      Privacy Policy
+     </span>
+    </a>
+   </div>
+   <p class="copyright">
+    © 2025 Dr. Florian Eisold. Inhalte urheberrechtlich
         geschützt. Für Kooperationen oder Nutzungsanfragen:
-        <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">florianeisold@outlook.de</a>
-      </p>
-    </footer>
+    <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">florianeisold@outlook.de</a>
+   </p>
+  </footer>
 
     <script src="scripts/main.min.js" defer></script>
   </body>

--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -1184,42 +1184,42 @@
   </main>
   <!-- Rechtliches -->
   <footer class="legal-footer">
-   <div class="footer-brand">
-    <a aria-label="IMHIS Startseite" class="footer-logo-link" href="/index.html">
-     <img alt="IMHIS Logo" class="footer-logo" data-alt-en="IMHIS logo" decoding="async" loading="lazy" height="28" src="assets/Logo_blau.svg" width="120"/>
-    </a>
-    <a aria-label="LinkedIn" class="social-link" href="https://www.linkedin.com/in/imhis/" rel="noopener noreferrer" target="_blank">
-     <svg aria-hidden="true" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.356V9h3.414v1.561h.049c.476-.9 1.637-1.852 3.37-1.852 3.601 0 4.268 2.37 4.268 5.455v6.288zM5.337 7.433a2.062 2.062 0 1 1 0-4.125 2.062 2.062 0 0 1 0 4.125zm1.777 13.019H3.56V9h3.554v11.452zM22.225 0H1.771C.791 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0z">
-      </path>
-     </svg>
-    </a>
-   </div>
-   <div class="legal-links">
-    <a href="/impressum.html">
-     <span class="lang lang-de">
-      Impressum
-     </span>
-     <span class="lang lang-en" hidden="">
-      Imprint
-     </span>
-    </a>
-    <a href="/datenschutz.html">
-     <span class="lang lang-de">
-      Datenschutz
-     </span>
-     <span class="lang lang-en" hidden="">
-      Privacy Policy
-     </span>
-    </a>
-   </div>
-   <p class="copyright">
-    © 2025 Dr. Florian Eisold. Inhalte urheberrechtlich
+    <div class="footer-brand">
+      <a aria-label="IMHIS Startseite" class="footer-logo-link" href="/index.html">
+        <img alt="IMHIS Logo" class="footer-logo" data-alt-en="IMHIS logo" decoding="async" loading="lazy" height="28" src="assets/Logo_blau.svg" width="120"/>
+      </a>
+      <a aria-label="LinkedIn" class="social-link" href="https://www.linkedin.com/in/imhis/" rel="noopener noreferrer" target="_blank">
+        <svg aria-hidden="true" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.356V9h3.414v1.561h.049c.476-.9 1.637-1.852 3.37-1.852 3.601 0 4.268 2.37 4.268 5.455v6.288zM5.337 7.433a2.062 2.062 0 1 1 0-4.125 2.062 2.062 0 0 1 0 4.125zm1.777 13.019H3.56V9h3.554v11.452zM22.225 0H1.771C.791 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0z">
+          </path>
+        </svg>
+      </a>
+    </div>
+    <div class="legal-links">
+      <a href="/impressum.html">
+        <span class="lang lang-de">
+          Impressum
+        </span>
+        <span class="lang lang-en" hidden="">
+          Imprint
+        </span>
+      </a>
+      <a href="/datenschutz.html">
+        <span class="lang lang-de">
+          Datenschutz
+        </span>
+        <span class="lang lang-en" hidden="">
+          Privacy Policy
+        </span>
+      </a>
+    </div>
+    <p class="copyright">
+      © 2025 Dr. Florian Eisold. Inhalte urheberrechtlich
         geschützt. Für Kooperationen oder Nutzungsanfragen:
-    <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">
-     florianeisold@outlook.de
-    </a>
-   </p>
+      <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">
+        florianeisold@outlook.de
+      </a>
+    </p>
   </footer>
 
   <script src="scripts/main.min.js" defer></script>

--- a/impressum.html
+++ b/impressum.html
@@ -320,48 +320,43 @@
       </a>
     </footer>
 
-    <footer class="legal-footer">
-      <div class="footer-brand">
-        <a aria-label="IMHIS Startseite" class="footer-logo-link" href="/index.html">
-          <img
-            alt="IMHIS Logo"
-            class="footer-logo"
-            data-alt-en="IMHIS logo"
-            decoding="async"
-            loading="lazy"
-            height="28"
-            src="assets/Logo_blau.svg"
-            width="120"
-          />
-        </a>
-        <a
-          aria-label="LinkedIn"
-          class="social-link"
-          href="https://www.linkedin.com/in/imhis/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          <svg aria-hidden="true" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.356V9h3.414v1.561h.049c.476-.9 1.637-1.852 3.37-1.852 3.601 0 4.268 2.37 4.268 5.455v6.288zM5.337 7.433a2.062 2.062 0 1 1 0-4.125 2.062 2.062 0 0 1 0 4.125zm1.777 13.019H3.56V9h3.554v11.452zM22.225 0H1.771C.791 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0z"></path>
-          </svg>
-        </a>
-      </div>
-      <div class="legal-links">
-        <a href="/impressum.html">
-          <span class="lang lang-de">Impressum</span>
-          <span class="lang lang-en" hidden>Imprint</span>
-        </a>
-        <a href="/datenschutz.html">
-          <span class="lang lang-de">Datenschutz</span>
-          <span class="lang lang-en" hidden>Privacy Policy</span>
-        </a>
-      </div>
-      <p class="copyright">
-        © 2025 Dr. Florian Eisold. Inhalte urheberrechtlich
+  <!-- Rechtliches -->
+  <footer class="legal-footer">
+   <div class="footer-brand">
+    <a aria-label="IMHIS Startseite" class="footer-logo-link" href="/index.html">
+     <img alt="IMHIS Logo" class="footer-logo" data-alt-en="IMHIS logo" decoding="async" loading="lazy" height="28" src="assets/Logo_blau.svg" width="120"/>
+    </a>
+    <a aria-label="LinkedIn" class="social-link" href="https://www.linkedin.com/in/imhis/" rel="noopener noreferrer" target="_blank">
+     <svg aria-hidden="true" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.025-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.356V9h3.414v1.561h.049c.476-.9 1.637-1.852 3.37-1.852 3.601 0 4.268 2.37 4.268 5.455v6.288zM5.337 7.433a2.062 2.062 0 1 1 0-4.125 2.062 2.062 0 0 1 0 4.125zm1.777 13.019H3.56V9h3.554v11.452zM22.225 0H1.771C.791 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.729C24 .774 23.2 0 22.222 0z">
+      </path>
+     </svg>
+    </a>
+   </div>
+   <div class="legal-links">
+    <a href="/impressum.html">
+     <span class="lang lang-de">
+      Impressum
+     </span>
+     <span class="lang lang-en" hidden="">
+      Imprint
+     </span>
+    </a>
+    <a href="/datenschutz.html">
+     <span class="lang lang-de">
+      Datenschutz
+     </span>
+     <span class="lang lang-en" hidden="">
+      Privacy Policy
+     </span>
+    </a>
+   </div>
+   <p class="copyright">
+    © 2025 Dr. Florian Eisold. Inhalte urheberrechtlich
         geschützt. Für Kooperationen oder Nutzungsanfragen:
-        <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">florianeisold@outlook.de</a>
-      </p>
-    </footer>
+    <a href="mailto:florianeisold@outlook.de?subject=Kontaktaufnahme%20IMHIS">florianeisold@outlook.de</a>
+   </p>
+  </footer>
 
     <script src="scripts/main.min.js" defer></script>
   </body>


### PR DESCRIPTION
## Summary
- replace the legal footer in datenschutz.html, impressum.html, and florian-eisold.html with the canonical markup from index.html
- ensure consistent language toggles, LinkedIn link, and copyright text across all pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6414e574883268d2ab038fa9d08ca