### PR TITLE
Prevent burger button background fill on toggle

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -243,6 +243,11 @@ a {
   transform: translateY(8px);
 }
 
+.nav-toggle:hover,
+.nav-toggle.open {
+  background: none;
+}
+
 .nav-toggle.open .hamburger {
   opacity: 0;
   transform: scaleX(0.35);


### PR DESCRIPTION
## Summary
- ensure the mobile navigation toggle keeps a transparent background when hovered or opened so only the lines animate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e690d3c0b883269b3111ea1b32063d