### PR TITLE
Verbessert Footer-CTA-Farbverlauf auf Index- und Profilseite

### DIFF
--- a/florian-eisold.html
+++ b/florian-eisold.html
@@ -554,11 +554,14 @@
 
       /* Call‑To‑Action Abschnitt */
       #cta {
-        background: radial-gradient(
-          circle at 30% 30%,
-          rgba(37, 99, 235, 0.15),
-          var(--color-accent-light)
-        );
+        background:
+          radial-gradient(
+            circle at 22% 12%,
+            rgba(37, 99, 235, 0.2) 0%,
+            rgba(37, 99, 235, 0) 58%
+          ),
+          linear-gradient(180deg, rgba(247, 251, 255, 0.96) 0%, #eef5ff 100%);
+        border-top: 1px solid rgba(148, 163, 184, 0.22);
         padding: 52px 20px;
         text-align: center;
       }

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -869,7 +869,15 @@ a {
 
 .contact-footer {
   text-align: center;
-  padding: 3rem 1rem;
+  padding: clamp(2.8rem, 5.5vw, 4rem) 1rem;
+  background:
+    radial-gradient(
+      circle at 22% 12%,
+      rgba(37, 99, 235, 0.2) 0%,
+      rgba(37, 99, 235, 0) 58%
+    ),
+    linear-gradient(180deg, rgba(247, 251, 255, 0.96) 0%, #eef5ff 100%);
+  border-top: 1px solid rgba(148, 163, 184, 0.22);
 }
 
 .contact-footer .footer-cta {


### PR DESCRIPTION
### Motivation
- Der Farbübergang im Margin-/Footer-Bereich der CTAs wirkte nicht nahtlos zum restlichen Seiten-Design und sollte auf der Start- und Profilseite optisch harmonisiert werden.

### Description
- Aktualisiert `styles/custom.css` für `.contact-footer`: responsives Padding eingeführt, radialer + linearer Verlauf ergänzt und eine dezente obere Trennlinie (`border-top`) hinzugefügt.
- Anpassung des CTA-Abschnitts `#cta` in `florian-eisold.html`: identischen zweistufigen Verlauf und dieselbe obere Trennlinie verwendet, um Konsistenz zwischen Profil- und Startseite herzustellen.
- Die Gradienten-Positionen und Alpha-Werte wurden feinjustiert, damit der Übergang weicher und markenkonformer erscheint.

### Testing
- Änderungen per Dateidiff geprüft gegen `styles/custom.css` und `florian-eisold.html` und die geänderten Stellen visuell durch Code-Review verifiziert (erfolgreich).
- Lokalen HTTP-Server mit `python3 -m http.server 4173` gestartet und ein Versuch unternommen, Seiten-Screenshots mit Playwright zu erstellen, wobei die Screenshot-Versuche aufgrund eines Chromium/Playwright-Absturzes (SIGSEGV) in der Umgebung fehlgeschlagen sind (fehlgeschlagen).
- `git status`/Diff-Überprüfung durchgeführt, die geänderten Dateien wurden wie erwartet erkannt (erfolgreich).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a82be6ab5c83268a1dbc200e218636)